### PR TITLE
Support saving comment emojis to the device album

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -128,6 +128,7 @@ dependencies {
 
     // ------------------ 底层与工具库 ------------------
     implementation(libs.luckypray.dexkit)
+    implementation(libs.gifkt)
 
     // ---------------------- HOOK ----------------------
     // 基础依赖

--- a/app/src/main/java/com/yst/mkga/hook/dy/hook/CommentEmojiHooker.kt
+++ b/app/src/main/java/com/yst/mkga/hook/dy/hook/CommentEmojiHooker.kt
@@ -18,156 +18,141 @@ object CommentEmojiHooker : YukiBaseHooker() {
     private val UrlModelClass by lazyClass("com.ss.android.ugc.aweme.base.model.UrlModel")
     private val SaveImageActionItemClass by lazyClass("com.ss.android.ugc.aweme.comment.manager.longclickaction.actions.SaveImageActionItem")
     private val CommentActionParamsClass by lazyClass("com.ss.android.ugc.aweme.comment.CommentActionParams")
-    private val CommentLongPressItemModelClass by lazyClass(
-        "com.ss.android.ugc.aweme.comment.ui.longpress.CommentLongPressItemModel"
-    )
-    private val CommentImageStructClass by lazyClass(
-        "com.ss.android.ugc.aweme.comment.model.CommentImageStruct"
-    )
-    private var saveImageActionItemClassCommentActionParamsField: Field? = null
-    private var commentActionParamsClassFragmentActivityField: Field? = null
-    private var commentActionParamsClassCommentField: Field? = null
-    private var commentActionParamsClassImageIndexField: Field? = null
-    private var CommentLongPressItemModelClassCommentActionParamsField: Field? = null
+    private val CommentLongPressItemModelClass by lazyClass("com.ss.android.ugc.aweme.comment.ui.longpress.CommentLongPressItemModel")
+    private val CommentImageStructClass by lazyClass("com.ss.android.ugc.aweme.comment.model.CommentImageStruct")
 
     private val CommentClassEmojiField: Field by lazy {
-        CommentClass.getDeclaredField("emoji").apply {
+        CommentClass.resolve().firstField {
+            name = "emoji"
+        }.self.apply {
             isAccessible = true
         }
     }
 
     private val EmojiClassAnimateUrlField: Field by lazy {
-        EmojiClass.getDeclaredField("animateUrl")
-            .apply {
-                isAccessible = true
-            }
+        EmojiClass.resolve().firstField {
+            name = "animateUrl"
+        }.self.apply {
+            isAccessible = true
+        }
     }
 
     private val UrlModelClassUrlListField: Field by lazy {
-        UrlModelClass.getDeclaredField("urlList").apply {
+        UrlModelClass.resolve().firstField {
+            name = "urlList"
+        }.self.apply {
             isAccessible = true
         }
     }
 
     private val CommentClassImageListField: Field by lazy {
-        CommentClass.getDeclaredField("imageList").apply {
+        CommentClass.resolve().firstField {
+            name = "imageList"
+        }.self.apply {
             isAccessible = true
         }
     }
 
     private val CommentImageStructClassDownloadUrlField: Field by lazy {
-        CommentImageStructClass.getDeclaredField("downloadUrl").apply {
+        CommentImageStructClass.resolve().firstField {
+            name = "downloadUrl"
+        }.self.apply {
             isAccessible = true
         }
     }
 
+    private var commentActionParamsClassCommentField: Field? = null
+    private var commentActionParamsClassImageIndexField: Field? = null
+    private var commentLongPressItemModelClassCommentActionParamsField: Field? = null
+    private var saveImageActionItemClassCommentActionParamsField: Field? = null
+
     override fun onHook() {
         withProcess(mainProcessName) {
             val transaction = HookTransaction(TAG)
-
             DexKitBridge.create(this.appInfo.sourceDir).use { bridge ->
-                transaction.add(::installSaveEmojiBtnHook.name) {
-                    installSaveEmojiBtnHook(bridge)
+                transaction.add(::installSaveEmojiToAlbumButtonHook.name) {
+                    installSaveEmojiToAlbumButtonHook(bridge)
                 }
-
-                transaction.add(::installSaveEmojiCallbackHook.name) {
-                    installSaveEmojiCallbackHook(bridge)
+                transaction.add(::installClickSaveEmojiToAlbumButtonCallbackHook.name) {
+                    installClickSaveEmojiToAlbumButtonCallbackHook(bridge)
                 }
-
                 transaction.commit()
             }
         }
     }
 
-    private fun getEmojiUrlListFromCommentOrNull(comment: Any?): List<String>? {
-        return runCatching {
-            val emoji = CommentClassEmojiField.get(comment)
-            val animateUrl = EmojiClassAnimateUrlField.get(emoji)
-            @Suppress("UNCHECKED_CAST")
-            (UrlModelClassUrlListField.get(animateUrl) as? List<String>)
-        }.getOrNull()
-    }
-
-    private fun getImageUrlListFromCommentOrNull(
-        comment: Any?,
-        imageIndex: Int = 0
-    ): List<String>? {
-        comment ?: return null
-
-        // start to extract image url list
-        val imageList = (CommentClassImageListField.get(comment) as? List<*>)
-            ?: return null//List<CommentImageStruct>
-
-        val imageStruct = imageList.getOrNull(imageIndex) ?: return null
-
-        val downloadUrlModel =
-            CommentImageStructClassDownloadUrlField.get(imageStruct) ?: return null
-
-        @Suppress("UNCHECKED_CAST")
-        val downloadUrlList = UrlModelClassUrlListField.get(downloadUrlModel) as? List<String>
-
-        return downloadUrlList
-    }
-
-    private fun getCommentFromSaveImageActionItemOrNull(saveImageActionItem: Any?): Any? {
-        saveImageActionItem ?: return null
-
-        val longPressActionParamsField = CommentLongPressItemModelClassCommentActionParamsField
-            ?: CommentLongPressItemModelClass.resolve().firstField {
+    private fun extractActionParams(actionItem: Any): Any? {
+        val field = commentLongPressItemModelClassCommentActionParamsField ?: CommentLongPressItemModelClass.resolve()
+            .firstField {
                 type = CommentActionParamsClass.name
             }.self.also {
                 it.isAccessible = true
-                CommentLongPressItemModelClassCommentActionParamsField = it
+                commentLongPressItemModelClassCommentActionParamsField = it
             }
-        val longPressActionParams =
-            longPressActionParamsField.get(saveImageActionItem) ?: return null
+        return field.get(actionItem)
+    }
 
-        // get comment
-        val commentField =
-            commentActionParamsClassCommentField ?: CommentActionParamsClass.resolve().firstField {
+    private fun extractComment(actionItem: Any): Any? {
+        val params = extractActionParams(actionItem) ?: return null
+        val field = commentActionParamsClassCommentField
+            ?: CommentActionParamsClass.resolve().firstField {
                 type = CommentClass.name
             }.self.also {
                 it.isAccessible = true
                 commentActionParamsClassCommentField = it
             }
-
-        return commentField.get(longPressActionParams)
+        return field.get(params)
     }
 
-    private fun getImageUrlListFromSaveImageActionItemOrNull(saveImageActionItem: Any?): List<String>? {
-        saveImageActionItem ?: return null
-
-        val actionParamsField =
-            saveImageActionItemClassCommentActionParamsField ?: SaveImageActionItemClass.resolve()
-                .firstField {
-                    type = CommentActionParamsClass.name
-                }.self.also {
-                    it.isAccessible = true
-                    saveImageActionItemClassCommentActionParamsField = it
-                }
-
-        val commentActionParams = actionParamsField.get(saveImageActionItem)
-
-        // get the image index from the long-pressed comment
-        val imageIndexField =
-            commentActionParamsClassImageIndexField ?: CommentActionParamsClass.resolve()
-                .firstField {
-                    type = Int::class
-                }.self.also {
-                    it.isAccessible = true
-                    commentActionParamsClassImageIndexField = it
-                }
-        val imageIndex = imageIndexField.get(commentActionParams) as Int
-
-        val comment = getCommentFromSaveImageActionItemOrNull(saveImageActionItem) ?: return null
-
-        return getImageUrlListFromCommentOrNull(comment, imageIndex)
+    private fun extractEmojiUrls(comment: Any): List<String>? {
+        return runCatching {
+            val emoji = CommentClassEmojiField.get(comment) ?: return@runCatching null
+            val animateUrl = EmojiClassAnimateUrlField.get(emoji) ?: return@runCatching null
+            @Suppress("UNCHECKED_CAST")
+            UrlModelClassUrlListField.get(animateUrl) as? List<String>
+        }.getOrNull()
     }
 
-    private fun installSaveEmojiBtnHook(bridge: DexKitBridge): YukiMemberHookCreator.MemberHookCreator.Result? {
+    private fun overrideImageIndex(actionItem: Any, index: Int) {
+        val paramsField = saveImageActionItemClassCommentActionParamsField
+            ?: SaveImageActionItemClass.resolve().firstField {
+                type = CommentActionParamsClass.name
+            }.self.also {
+                it.isAccessible = true
+                saveImageActionItemClassCommentActionParamsField = it
+            }
+
+        val params = paramsField.get(actionItem) ?: return
+        val field = commentActionParamsClassImageIndexField
+            ?: CommentActionParamsClass.resolve().firstField {
+                type = Int::class
+            }.self.also {
+                it.isAccessible = true
+                commentActionParamsClassImageIndexField = it
+            }
+        field.set(params, index)
+    }
+
+    private fun replaceImageUrls(comment: Any, urls: List<String>) {
+        var imageList = CommentClassImageListField.get(comment) as? List<*>
+        if (imageList.isNullOrEmpty()) {
+            val newStruct = CommentImageStructClass.getConstructor().newInstance()
+            imageList = listOf(newStruct)
+            CommentClassImageListField.set(comment, imageList)
+        }
+
+        val targetStruct = imageList[0]
+        var urlModel = CommentImageStructClassDownloadUrlField.get(targetStruct)
+        if (urlModel == null) {
+            urlModel = UrlModelClass.getConstructor().newInstance()
+            CommentImageStructClassDownloadUrlField.set(targetStruct, urlModel)
+        }
+        UrlModelClassUrlListField.set(urlModel, urls)
+    }
+
+    private fun installSaveEmojiToAlbumButtonHook(bridge: DexKitBridge): YukiMemberHookCreator.MemberHookCreator.Result? {
         var ret: YukiMemberHookCreator.MemberHookCreator.Result? = null
 
-        // Force enable "Save to Album" button for emoji comments
         bridge.findMethod {
             matcher {
                 modifiers = Modifier.STATIC
@@ -177,9 +162,8 @@ object CommentEmojiHooker : YukiBaseHooker() {
                 }
                 returnType = "boolean"
                 invokeMethods {
-                    // TODO: This method has already been looked up in CommentImageHooker, consider caching and sharing it here
                     add {
-                        declaredClass = "com.ss.android.ugc.aweme.comment.model.CommentImageStruct"
+                        declaredClass = CommentImageStructClass.name
                         returnType = UrlModelClass.name
                         paramCount = 0
                         addUsingField {
@@ -191,39 +175,34 @@ object CommentEmojiHooker : YukiBaseHooker() {
         }.singleOrNull()?.also { result ->
             YLog.debug("$TAG: Target method found: ${result.className}.${result.methodName}")
 
-            result.className.toClass().resolve().firstMethod {
-                name = result.methodName
-            }.hook {
+            result.className.toClass().resolve().firstMethod { name = result.methodName }.hook {
                 before {
                     val comment = args[0] ?: return@before
-
-                    val emojiUrlList = getEmojiUrlListFromCommentOrNull(comment)
-                    if (emojiUrlList?.isNotEmpty() == true) {
+                    val emojiUrls = extractEmojiUrls(comment)
+                    if (!emojiUrls.isNullOrEmpty()) {
                         resultTrue()
                     }
                 }
             }.result {
-                onHookingFailure { throwable ->
-                    YLog.error("$TAG: Unable to replace with original emoji URL: ${throwable.message}")
-                }
                 onConductFailure { param, throwable ->
-                    YLog.error("$TAG: Error during download callback hook: ${throwable.message}")
-                    param.result = param.callOriginal()
+                    YLog.error("$TAG: Save emoji button hook runtime error", throwable)
+                }
+                onHookingFailure { throwable ->
+                    YLog.error("$TAG: Failed to hook save emoji button", throwable)
                 }
                 onHooked {
-                    YLog.info("$TAG: Hook installed, 'Save to album' button will show for emoji comments")
+                    YLog.info("$TAG: Save emoji button hook installed successfully. The button will be shown for emoji comments")
                 }.also {
                     ret = it
                 }
             }
         } ?: run {
-            YLog.warn("$TAG: Target method not found, save to album feature is not active")
+            YLog.warn("$TAG: Target method not found, save emoji to album button will not be shown")
         }
-
         return ret
     }
 
-    private fun installSaveEmojiCallbackHook(bridge: DexKitBridge): YukiMemberHookCreator.MemberHookCreator.Result? {
+    private fun installClickSaveEmojiToAlbumButtonCallbackHook(bridge: DexKitBridge): YukiMemberHookCreator.MemberHookCreator.Result? {
         var ret: YukiMemberHookCreator.MemberHookCreator.Result? = null
 
         bridge.findMethod {
@@ -238,46 +217,44 @@ object CommentEmojiHooker : YukiBaseHooker() {
         }.singleOrNull()?.also { result ->
             YLog.debug("$TAG: Target method found: ${result.className}.${result.methodName}")
 
-            result.className.toClass().resolve().firstMethod {
-                name = result.methodName
-            }.hook {
+            result.className.toClass().resolve().firstMethod { name = result.methodName }.hook {
                 before {
-                    val cbkInstance = args[0] ?: run {
-                        YLog.debug("$TAG: Failed to extract cbkInstance from args")
-                        return@before
-                    }
+                    val cbkInstance = args[0] ?: return@before
 
-                    val saveImageActionItem = cbkInstance.asResolver().firstField {
-                        type = "java.lang.Object"
-                    }.get() ?: run {
-                        YLog.debug("$TAG: Failed to extract saveImageActionItem from args")
-                        return@before
-                    }
+                    val actionItem = cbkInstance.asResolver().firstField {
+                        type = Object::class
+                    }.get() ?: return@before
 
-                    val comment = getCommentFromSaveImageActionItemOrNull(saveImageActionItem)
-                        ?: return@before
+                    val comment = extractComment(actionItem) ?: return@before
+                    val emojiUrls = extractEmojiUrls(comment) ?: return@before
 
-                    val emojiUrlList = getEmojiUrlListFromCommentOrNull(comment) ?: return@before
+                    overrideImageIndex(actionItem, 0)
+                    //TODO: prepend emoji urls to image url list
+                    replaceImageUrls(comment, emojiUrls)
 
-                    YLog.warn("$TAG: Download Emoji Function is NOT IMPLEMENT yet, got ${emojiUrlList.size} emoji url(s)")
-                    return@before
+                    YLog.debug("$TAG: Injected ${emojiUrls.size} emoji url(s) into comment.")
+
+                    YLog.warn("$TAG: HEIF to GIF conversion not yet implemented, saved file may not be viewable in gallery")
                 }
+                // TODO: restore original image URL list after emoji URL injection
+                /* after{
+
+                } */
             }.result {
                 onConductFailure { param, throwable ->
-                    YLog.error("$TAG: Error during download callback hook: ${throwable.message}")
-                    param.result = param.callOriginal()
+                    YLog.error("$TAG: Download callback hook runtime error", throwable)
                 }
                 onHookingFailure { throwable ->
-                    YLog.error("$TAG: Failed to install download callback hook: ${throwable.message}")
+                    YLog.error("$TAG: Failed to hook download callback", throwable)
                 }
                 onHooked {
-                    YLog.info("$TAG: Download callback hook installed, emoji download function is active")
+                    YLog.info("$TAG: Download callback hook installed successfully. Emoji URLs will be injected when saving")
                 }.also {
                     ret = it
                 }
             }
         } ?: run {
-            YLog.warn("$TAG: Target method not found, emoji download function is not active")
+            YLog.warn("$TAG: Target method not found, download callback hook will not be installed")
         }
 
         return ret

--- a/app/src/main/java/com/yst/mkga/hook/dy/hook/CommentEmojiHooker.kt
+++ b/app/src/main/java/com/yst/mkga/hook/dy/hook/CommentEmojiHooker.kt
@@ -1,0 +1,68 @@
+package com.yst.mkga.hook.dy.hook
+
+import com.highcapable.kavaref.KavaRef.Companion.asResolver
+import com.highcapable.kavaref.KavaRef.Companion.resolve
+import com.highcapable.yukihookapi.hook.entity.YukiBaseHooker
+import com.highcapable.yukihookapi.hook.log.YLog
+import org.luckypray.dexkit.DexKitBridge
+import java.lang.reflect.Modifier
+
+
+object CommentEmojiHooker : YukiBaseHooker() {
+    override fun onHook() {
+        loadApp(name = "com.ss.android.ugc.aweme") {
+            DexKitBridge.create(this.appInfo.sourceDir).use { bridge ->
+                bridge.findMethod {
+                    matcher {
+                        modifiers = Modifier.STATIC
+                        params {
+                            add("com.ss.android.ugc.aweme.comment.model.Comment")
+                            add("int")
+                        }
+                        returnType = "boolean"
+                        invokeMethods {
+                            // TODO: This method has already been looked up in CommentImageHooker, consider caching and sharing it here
+                            add {
+                                declaredClass =
+                                    "com.ss.android.ugc.aweme.comment.model.CommentImageStruct"
+                                returnType = "com.ss.android.ugc.aweme.base.model.UrlModel"
+                                paramCount = 0
+                                addUsingField {
+                                    name = "downloadUrl"
+                                }
+                            }
+                        }
+                    }
+                }.singleOrNull()?.also { result ->
+                    YLog.debug("CommentEmojiHooker: Target method found: ${result.className}.${result.methodName}")
+
+                    result.className.toClass().resolve().firstMethod {
+                        name = result.methodName
+                    }.hook {
+                        before {
+                            val comment = args[0]
+                            val emojiUrlList = comment?.asResolver()?.firstField {
+                                name = "emoji"
+                            }?.get()?.asResolver()?.firstField {
+                                name = "animateUrl"
+                            }?.get()?.asResolver()?.firstField {
+                                name = "urlList"
+                            }?.get<List<String>>()
+
+                            if (emojiUrlList?.isNotEmpty() == true) {
+                                resultTrue()
+                            }
+                        }
+                    }.result {
+                        onConductFailure { param, throwable ->
+                            YLog.error("CommentEmojiHooker: Unable to replace with original emoji URL: ${throwable.message}")
+                            param.result = param.callOriginal()
+                        }
+                    }
+                } ?: run {
+                    YLog.warn("CommentEmojiHooker: Target method not found, comment emoji download is not active")
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/yst/mkga/hook/dy/hook/CommentEmojiHooker.kt
+++ b/app/src/main/java/com/yst/mkga/hook/dy/hook/CommentEmojiHooker.kt
@@ -18,9 +18,17 @@ object CommentEmojiHooker : YukiBaseHooker() {
     private val UrlModelClass by lazyClass("com.ss.android.ugc.aweme.base.model.UrlModel")
     private val SaveImageActionItemClass by lazyClass("com.ss.android.ugc.aweme.comment.manager.longclickaction.actions.SaveImageActionItem")
     private val CommentActionParamsClass by lazyClass("com.ss.android.ugc.aweme.comment.CommentActionParams")
+    private val CommentLongPressItemModelClass by lazyClass(
+        "com.ss.android.ugc.aweme.comment.ui.longpress.CommentLongPressItemModel"
+    )
+    private val CommentImageStructClass by lazyClass(
+        "com.ss.android.ugc.aweme.comment.model.CommentImageStruct"
+    )
     private var saveImageActionItemClassCommentActionParamsField: Field? = null
     private var commentActionParamsClassFragmentActivityField: Field? = null
     private var commentActionParamsClassCommentField: Field? = null
+    private var commentActionParamsClassImageIndexField: Field? = null
+    private var CommentLongPressItemModelClassCommentActionParamsField: Field? = null
 
     private val CommentClassEmojiField: Field by lazy {
         CommentClass.getDeclaredField("emoji").apply {
@@ -37,6 +45,18 @@ object CommentEmojiHooker : YukiBaseHooker() {
 
     private val UrlModelClassUrlListField: Field by lazy {
         UrlModelClass.getDeclaredField("urlList").apply {
+            isAccessible = true
+        }
+    }
+
+    private val CommentClassImageListField: Field by lazy {
+        CommentClass.getDeclaredField("imageList").apply {
+            isAccessible = true
+        }
+    }
+
+    private val CommentImageStructClassDownloadUrlField: Field by lazy {
+        CommentImageStructClass.getDeclaredField("downloadUrl").apply {
             isAccessible = true
         }
     }
@@ -66,6 +86,82 @@ object CommentEmojiHooker : YukiBaseHooker() {
             @Suppress("UNCHECKED_CAST")
             (UrlModelClassUrlListField.get(animateUrl) as? List<String>)
         }.getOrNull()
+    }
+
+    private fun getImageUrlListFromCommentOrNull(
+        comment: Any?,
+        imageIndex: Int = 0
+    ): List<String>? {
+        comment ?: return null
+
+        // start to extract image url list
+        val imageList = (CommentClassImageListField.get(comment) as? List<*>)
+            ?: return null//List<CommentImageStruct>
+
+        val imageStruct = imageList.getOrNull(imageIndex) ?: return null
+
+        val downloadUrlModel =
+            CommentImageStructClassDownloadUrlField.get(imageStruct) ?: return null
+
+        @Suppress("UNCHECKED_CAST")
+        val downloadUrlList = UrlModelClassUrlListField.get(downloadUrlModel) as? List<String>
+
+        return downloadUrlList
+    }
+
+    private fun getCommentFromSaveImageActionItemOrNull(saveImageActionItem: Any?): Any? {
+        saveImageActionItem ?: return null
+
+        val longPressActionParamsField = CommentLongPressItemModelClassCommentActionParamsField
+            ?: CommentLongPressItemModelClass.resolve().firstField {
+                type = CommentActionParamsClass.name
+            }.self.also {
+                it.isAccessible = true
+                CommentLongPressItemModelClassCommentActionParamsField = it
+            }
+        val longPressActionParams =
+            longPressActionParamsField.get(saveImageActionItem) ?: return null
+
+        // get comment
+        val commentField =
+            commentActionParamsClassCommentField ?: CommentActionParamsClass.resolve().firstField {
+                type = CommentClass.name
+            }.self.also {
+                it.isAccessible = true
+                commentActionParamsClassCommentField = it
+            }
+
+        return commentField.get(longPressActionParams)
+    }
+
+    private fun getImageUrlListFromSaveImageActionItemOrNull(saveImageActionItem: Any?): List<String>? {
+        saveImageActionItem ?: return null
+
+        val actionParamsField =
+            saveImageActionItemClassCommentActionParamsField ?: SaveImageActionItemClass.resolve()
+                .firstField {
+                    type = CommentActionParamsClass.name
+                }.self.also {
+                    it.isAccessible = true
+                    saveImageActionItemClassCommentActionParamsField = it
+                }
+
+        val commentActionParams = actionParamsField.get(saveImageActionItem)
+
+        // get the image index from the long-pressed comment
+        val imageIndexField =
+            commentActionParamsClassImageIndexField ?: CommentActionParamsClass.resolve()
+                .firstField {
+                    type = Int::class
+                }.self.also {
+                    it.isAccessible = true
+                    commentActionParamsClassImageIndexField = it
+                }
+        val imageIndex = imageIndexField.get(commentActionParams) as Int
+
+        val comment = getCommentFromSaveImageActionItemOrNull(saveImageActionItem) ?: return null
+
+        return getImageUrlListFromCommentOrNull(comment, imageIndex)
     }
 
     private fun installSaveEmojiBtnHook(bridge: DexKitBridge): YukiMemberHookCreator.MemberHookCreator.Result? {
@@ -158,41 +254,10 @@ object CommentEmojiHooker : YukiBaseHooker() {
                         return@before
                     }
 
-                    val commentActionParamsField =
-                        saveImageActionItemClassCommentActionParamsField ?: runCatching {
-                            SaveImageActionItemClass.resolve().firstField {
-                                type = CommentActionParamsClass.name
-                            }.self.also {
-                                saveImageActionItemClassCommentActionParamsField = it
-                            }
-                        }.onFailure {
-                            YLog.error("$TAG: Failed to find CommentActionParams field in SaveImageActionItem: ${it.message}")
-                        }.getOrNull()
+                    val comment = getCommentFromSaveImageActionItemOrNull(saveImageActionItem)
+                        ?: return@before
 
-                    val commentActionParams =
-                        commentActionParamsField?.get(saveImageActionItem) ?: run {
-                            YLog.debug("$TAG: Failed to get CommentActionParams from SaveImageActionItem")
-                            return@before
-                        }
-
-                    val commentField = commentActionParamsClassCommentField ?: runCatching {
-                        CommentActionParamsClass.resolve().firstField {
-                            type = CommentClass.name
-                        }.self.also {
-                            commentActionParamsClassCommentField = it
-                        }
-                    }.onFailure {
-                        YLog.error("$TAG: Failed to find Comment field in CommentActionParams: ${it.message}")
-                    }.getOrNull()
-
-                    val comment = commentField?.get(commentActionParams) ?: run {
-                        YLog.debug("$TAG: Failed to get Comment from CommentActionParams")
-                        return@before
-                    }
-
-                    val emojiUrlList = getEmojiUrlListFromCommentOrNull(comment)?.takeIf {
-                        it.isNotEmpty()
-                    } ?: return@before
+                    val emojiUrlList = getEmojiUrlListFromCommentOrNull(comment) ?: return@before
 
                     YLog.warn("$TAG: Download Emoji Function is NOT IMPLEMENT yet, got ${emojiUrlList.size} emoji url(s)")
                     return@before

--- a/app/src/main/java/com/yst/mkga/hook/dy/hook/CommentEmojiHooker.kt
+++ b/app/src/main/java/com/yst/mkga/hook/dy/hook/CommentEmojiHooker.kt
@@ -1,18 +1,31 @@
 package com.yst.mkga.hook.dy.hook
 
 import android.content.Context
+import android.graphics.Bitmap
+import android.media.MediaExtractor
+import android.media.MediaFormat
+import android.media.MediaMetadataRetriever
+import android.os.Build
+import java.io.File
+import java.lang.reflect.Field
+import java.lang.reflect.Method
+import java.lang.reflect.Modifier
+import kotlinx.io.buffered
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import kotlinx.io.Sink
+import kotlin.time.Duration.Companion.milliseconds
+
 import com.highcapable.kavaref.KavaRef.Companion.asResolver
 import com.highcapable.kavaref.KavaRef.Companion.resolve
 import com.highcapable.kavaref.condition.type.Modifiers
 import com.highcapable.yukihookapi.hook.core.YukiMemberHookCreator
 import com.highcapable.yukihookapi.hook.entity.YukiBaseHooker
 import com.highcapable.yukihookapi.hook.log.YLog
-import com.yst.mkga.hook.dy.hook.utils.HookTransaction
+import com.shakster.gifkt.GifEncoder
 import org.luckypray.dexkit.DexKitBridge
-import java.io.File
-import java.lang.reflect.Field
-import java.lang.reflect.Method
-import java.lang.reflect.Modifier
+
+import com.yst.mkga.hook.dy.hook.utils.HookTransaction
 
 object CommentEmojiHooker : YukiBaseHooker() {
     private val TAG = this::class.simpleName
@@ -123,7 +136,13 @@ object CommentEmojiHooker : YukiBaseHooker() {
             name = "getImageUri"
             returnType = android.net.Uri::class
             modifiers(Modifiers.PUBLIC, Modifiers.STATIC, Modifiers.FINAL)
-            parameters(android.content.Context::class, String::class, String::class, String::class, TokenCertClass)
+            parameters(
+                android.content.Context::class,
+                String::class,
+                String::class,
+                String::class,
+                TokenCertClass
+            )
             parameterCount = 5
         }.self.apply {
             isAccessible = true
@@ -234,11 +253,131 @@ object CommentEmojiHooker : YukiBaseHooker() {
         return field.get(params)
     }
 
-    private fun convertHeif2Gif(heifPath: String, gifPath: String): Boolean {
-        return runCatching {
-            File(heifPath).copyTo(File(gifPath), overwrite = true)
-            true
-        }.getOrDefault(false)
+    private fun convertMedia2Gif(mediaPath: String, gifPath: String): Boolean {
+        var extractor: MediaExtractor? = null
+        var retriever: MediaMetadataRetriever? = null
+        var encoder: GifEncoder? = null
+        var sink: Sink? = null
+
+        try {
+            // 1. Initialize MediaExtractor
+            extractor = MediaExtractor().apply {
+                setDataSource(mediaPath)
+            }
+
+            // Find the visual track
+            var trackIndex = -1
+            for (i in 0 until extractor.trackCount) {
+                val format = extractor.getTrackFormat(i)
+                val mime = format.getString(MediaFormat.KEY_MIME) ?: ""
+                YLog.debug("$TAG: track[$i] mime=$mime")
+                if (mime.startsWith("video/") || mime.startsWith("image/")) {
+                    trackIndex = i
+                    break
+                }
+            }
+
+            // If no track is found, we can't process it
+            if (trackIndex == -1) {
+                YLog.warn("$TAG: No video/image track found in $mediaPath")
+                return false
+            }
+            extractor.selectTrack(trackIndex)
+
+            // 2. Iterate to fetch timestamps
+            val timestampsUs = mutableListOf<Long>()
+            while (true) {
+                val time = extractor.sampleTime
+                if (time < 0) {
+                    break // End of stream
+                }
+                timestampsUs.add(time)
+                extractor.advance()
+            }
+
+            if (timestampsUs.isEmpty()) {
+                YLog.warn("$TAG: No timestamps extracted from $mediaPath")
+                return false
+            }
+
+            // 3. Initialize MediaMetadataRetriever
+            retriever = MediaMetadataRetriever()
+            retriever.setDataSource(mediaPath)
+
+            // 4. Initialize gif.kt Multiplatform Encoder
+            val outPath = Path(gifPath)
+            sink = SystemFileSystem.sink(outPath).buffered()
+            encoder = GifEncoder(sink)
+
+            // 5. Process each frame
+            for (i in timestampsUs.indices) {
+                val currentUs = timestampsUs[i]
+
+                // Calculate delay: difference to next timestamp, duplicate the previous delta for the final frame
+                val nextUs = if (i + 1 < timestampsUs.size) {
+                    timestampsUs[i + 1]
+                } else {
+                    if (i > 0) timestampsUs[i] + (timestampsUs[i] - timestampsUs[i - 1]) else currentUs + 100_000L
+                }
+
+                val delayMs = ((nextUs - currentUs) / 1000L).coerceAtLeast(10L)
+
+                // Extract frame
+                var bitmap: Bitmap? = null
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                    try {
+                        // Try by index for animated
+                        bitmap = retriever.getFrameAtIndex(i)
+                    } catch (e: Exception) {
+                        // Fallback
+                    }
+                }
+
+                // Fallback for static or if index retrieval fails
+                if (bitmap == null) {
+                    // If it's a single frame, getFrameAtTime(0) works reliably for HEIC
+                    bitmap =
+                        retriever.getFrameAtTime(currentUs, MediaMetadataRetriever.OPTION_CLOSEST)
+                }
+
+                if (bitmap == null) continue
+
+                val width = bitmap.width
+                val height = bitmap.height
+                val pixels = IntArray(width * height)
+
+                // 6. Convert Bitmap to IntArray
+                bitmap.getPixels(pixels, 0, width, 0, 0, width, height)
+
+                // 7. Write frame to GIF
+                encoder.writeFrame(pixels, width, height, delayMs.milliseconds)
+
+                bitmap.recycle()
+            }
+
+            return true
+        } catch (e: Exception) {
+            YLog.error("$TAG: convertMedia2Gif failed", e)
+            return false
+        } finally {
+            // Enforce rigorous cleanup
+            try {
+                extractor?.release()
+            } catch (e: Exception) {
+            }
+            try {
+                retriever?.release()
+            } catch (e: Exception) {
+            }
+            try {
+                encoder?.close()
+            } catch (e: Exception) {
+            }
+            try {
+                sink?.close()
+            } catch (e: Exception) {
+            }
+        }
     }
 
     private fun extractEmojiUrls(comment: Any): List<String>? {
@@ -392,7 +531,13 @@ object CommentEmojiHooker : YukiBaseHooker() {
 
                     injectEmojiUrls(comment, emojiUrls, prepend = true)
 
-                    YLog.debug("$TAG: Injected ${emojiUrls.size} emoji url(s) into comment.")
+                    YLog.debug(
+                        "$TAG: Injected ${emojiUrls.size} emoji url(s) into comment, emoji url list[0]: ${
+                            emojiUrls.getOrNull(
+                                0
+                            ) ?: "null"
+                        }"
+                    )
 
                     YLog.warn("$TAG: HEIF to GIF conversion not yet implemented, saved file may not be viewable in gallery")
                 }
@@ -489,7 +634,8 @@ object CommentEmojiHooker : YukiBaseHooker() {
                         ) as String
                     }${File.separator}${gifFileName}"
                     YLog.debug("$TAG: GIF temp path: $gifTempPath")
-                    if (!convertHeif2Gif(sourcePath, gifTempPath)) {
+
+                    if (!convertMedia2Gif(sourcePath, gifTempPath)) {
                         YLog.error("$TAG: Convert HEIF To GIF failed")
                         return@before
                     }
@@ -584,7 +730,6 @@ object CommentEmojiHooker : YukiBaseHooker() {
                 ) as? android.net.Uri ?: return@after
                 result = finalUri
                 YLog.debug("$TAG: finalUri: $finalUri")
-
 
                 @Suppress("UNCHECKED_CAST")
                 val uriArr = args[2] as? Array<android.net.Uri> ?: return@after

--- a/app/src/main/java/com/yst/mkga/hook/dy/hook/CommentEmojiHooker.kt
+++ b/app/src/main/java/com/yst/mkga/hook/dy/hook/CommentEmojiHooker.kt
@@ -113,7 +113,7 @@ object CommentEmojiHooker : YukiBaseHooker() {
         }.getOrNull()
     }
 
-    private fun overrideImageIndex(actionItem: Any, index: Int) {
+    private fun overrideImageIndex(actionItem: Any, index: Int): Int {
         val paramsField = saveImageActionItemClassCommentActionParamsField
             ?: SaveImageActionItemClass.resolve().firstField {
                 type = CommentActionParamsClass.name
@@ -122,7 +122,7 @@ object CommentEmojiHooker : YukiBaseHooker() {
                 saveImageActionItemClassCommentActionParamsField = it
             }
 
-        val params = paramsField.get(actionItem) ?: return
+        val params = paramsField.get(actionItem) ?: return -1
         val field = commentActionParamsClassImageIndexField
             ?: CommentActionParamsClass.resolve().firstField {
                 type = Int::class
@@ -130,10 +130,13 @@ object CommentEmojiHooker : YukiBaseHooker() {
                 it.isAccessible = true
                 commentActionParamsClassImageIndexField = it
             }
+
+        val originImageIndex = field.get(params) as Int
         field.set(params, index)
+        return originImageIndex
     }
 
-    private fun replaceImageUrls(comment: Any, urls: List<String>) {
+    private fun injectEmojiUrls(comment: Any, emojiUrls: List<String>, prepend: Boolean = true) {
         var imageList = CommentClassImageListField.get(comment) as? List<*>
         if (imageList.isNullOrEmpty()) {
             val newStruct = CommentImageStructClass.getConstructor().newInstance()
@@ -147,7 +150,19 @@ object CommentEmojiHooker : YukiBaseHooker() {
             urlModel = UrlModelClass.getConstructor().newInstance()
             CommentImageStructClassDownloadUrlField.set(targetStruct, urlModel)
         }
-        UrlModelClassUrlListField.set(urlModel, urls)
+
+        var finalUrls: List<String>? = if (prepend) {
+            @Suppress("UNCHECKED_CAST")
+            val imageUrls = UrlModelClassUrlListField.get(urlModel) as? List<String>
+            if (imageUrls.isNullOrEmpty()) {
+                emojiUrls
+            } else {
+                emojiUrls + imageUrls
+            }
+        } else {
+            emojiUrls
+        }
+        UrlModelClassUrlListField.set(urlModel, finalUrls)
     }
 
     private fun installSaveEmojiToAlbumButtonHook(bridge: DexKitBridge): YukiMemberHookCreator.MemberHookCreator.Result? {
@@ -218,6 +233,10 @@ object CommentEmojiHooker : YukiBaseHooker() {
             YLog.debug("$TAG: Target method found: ${result.className}.${result.methodName}")
 
             result.className.toClass().resolve().firstMethod { name = result.methodName }.hook {
+                var savedComment: Any? = null
+                var savedActionItem: Any? = null
+                var originImageUrlList: List<*>? = null
+                var originImageIndex = -1
                 before {
                     val cbkInstance = args[0] ?: return@before
 
@@ -228,18 +247,32 @@ object CommentEmojiHooker : YukiBaseHooker() {
                     val comment = extractComment(actionItem) ?: return@before
                     val emojiUrls = extractEmojiUrls(comment) ?: return@before
 
-                    overrideImageIndex(actionItem, 0)
-                    //TODO: prepend emoji urls to image url list
-                    replaceImageUrls(comment, emojiUrls)
+                    // store original state for after
+                    originImageUrlList = CommentClassImageListField.get(comment) as? List<*>
+                    originImageIndex = overrideImageIndex(actionItem, 0)
+                    savedActionItem = actionItem
+                    savedComment = comment
+
+                    injectEmojiUrls(comment, emojiUrls, prepend = true)
 
                     YLog.debug("$TAG: Injected ${emojiUrls.size} emoji url(s) into comment.")
 
                     YLog.warn("$TAG: HEIF to GIF conversion not yet implemented, saved file may not be viewable in gallery")
                 }
-                // TODO: restore original image URL list after emoji URL injection
-                /* after{
-
-                } */
+                after {
+                    savedComment?.let { c ->
+                        CommentClassImageListField.set(c, originImageUrlList)
+                        if (originImageIndex >= 0) {
+                            savedActionItem?.let {
+                                overrideImageIndex(it, originImageIndex)
+                            }
+                        }
+                    }
+                    savedComment = null
+                    savedActionItem = null
+                    originImageUrlList = null
+                    originImageIndex = -1
+                }
             }.result {
                 onConductFailure { param, throwable ->
                     YLog.error("$TAG: Download callback hook runtime error", throwable)

--- a/app/src/main/java/com/yst/mkga/hook/dy/hook/CommentEmojiHooker.kt
+++ b/app/src/main/java/com/yst/mkga/hook/dy/hook/CommentEmojiHooker.kt
@@ -2,12 +2,13 @@ package com.yst.mkga.hook.dy.hook
 
 import com.highcapable.kavaref.KavaRef.Companion.asResolver
 import com.highcapable.kavaref.KavaRef.Companion.resolve
+import com.highcapable.yukihookapi.hook.core.YukiMemberHookCreator
 import com.highcapable.yukihookapi.hook.entity.YukiBaseHooker
 import com.highcapable.yukihookapi.hook.log.YLog
+import com.yst.mkga.hook.dy.hook.utils.HookTransaction
 import org.luckypray.dexkit.DexKitBridge
 import java.lang.reflect.Field
 import java.lang.reflect.Modifier
-
 
 object CommentEmojiHooker : YukiBaseHooker() {
     private val TAG = this::class.simpleName
@@ -42,141 +43,18 @@ object CommentEmojiHooker : YukiBaseHooker() {
 
     override fun onHook() {
         withProcess(mainProcessName) {
+            val transaction = HookTransaction(TAG)
+
             DexKitBridge.create(this.appInfo.sourceDir).use { bridge ->
-                // Force enable "Save to Album" button for emoji comments
-                bridge.findMethod {
-                    matcher {
-                        modifiers = Modifier.STATIC
-                        params {
-                            add(CommentClass.name)
-                            add("int")
-                        }
-                        returnType = "boolean"
-                        invokeMethods {
-                            // TODO: This method has already been looked up in CommentImageHooker, consider caching and sharing it here
-                            add {
-                                declaredClass =
-                                    "com.ss.android.ugc.aweme.comment.model.CommentImageStruct"
-                                returnType = UrlModelClass.name
-                                paramCount = 0
-                                addUsingField {
-                                    name = "downloadUrl"
-                                }
-                            }
-                        }
-                    }
-                }.singleOrNull()?.also { result ->
-                    YLog.debug("$TAG: Target method found: ${result.className}.${result.methodName}")
-
-                    result.className.toClass().resolve().firstMethod {
-                        name = result.methodName
-                    }.hook {
-                        before {
-                            val comment = args[0] ?: return@before
-
-                            val emojiUrlList = getEmojiUrlListFromCommentOrNull(comment)
-                            if (emojiUrlList?.isNotEmpty() == true) {
-                                resultTrue()
-                            }
-                        }
-                    }.result {
-                        onHookingFailure { throwable ->
-                            YLog.error("$TAG: Unable to replace with original emoji URL: ${throwable.message}")
-                        }
-                        onConductFailure { param, throwable ->
-                            YLog.error("$TAG: Error during download callback hook: ${throwable.message}")
-                            param.result = param.callOriginal()
-                        }
-                        onHooked {
-                            YLog.info("$TAG: Hook installed, 'Save to album' button will show for emoji comments")
-                        }
-                    }
-                } ?: run {
-                    YLog.warn("$TAG: Target method not found, save to album feature is not active")
+                transaction.add(::installSaveEmojiBtnHook.name) {
+                    installSaveEmojiBtnHook(bridge)
                 }
 
-                bridge.findMethod {
-                    matcher {
-                        modifiers = Modifier.STATIC + Modifier.FINAL + Modifier.PUBLIC
-                        returnType = "java.lang.Object"
-                        params {
-                            count = 1
-                        }
-                        addUsingString("bpea-comment_save_image_to_album")
-                    }
-                }.singleOrNull()?.also { result ->
-                    YLog.debug("$TAG: Target method found: ${result.className}.${result.methodName}")
-
-                    result.className.toClass().resolve().firstMethod {
-                        name = result.methodName
-                    }.hook {
-                        before {
-                            val cbkInstance = args[0] ?: run {
-                                YLog.debug("$TAG: Failed to extract cbkInstance from args")
-                                return@before
-                            }
-
-                            val saveImageActionItem = cbkInstance.asResolver().firstField {
-                                type = "java.lang.Object"
-                            }.get() ?: run {
-                                YLog.debug("$TAG: Failed to extract saveImageActionItem from args")
-                                return@before
-                            }
-
-                            val commentActionParamsField =
-                                saveImageActionItemClassCommentActionParamsField ?: runCatching {
-                                    SaveImageActionItemClass.resolve().firstField {
-                                        type = CommentActionParamsClass.name
-                                    }.self.also {
-                                        saveImageActionItemClassCommentActionParamsField = it
-                                    }
-                                }.onFailure {
-                                    YLog.error("$TAG: Failed to find CommentActionParams field in SaveImageActionItem: ${it.message}")
-                                }.getOrNull()
-
-                            val commentActionParams =
-                                commentActionParamsField?.get(saveImageActionItem) ?: run {
-                                    YLog.debug("$TAG: Failed to get CommentActionParams from SaveImageActionItem")
-                                    return@before
-                                }
-
-                            val commentField = commentActionParamsClassCommentField ?: runCatching {
-                                CommentActionParamsClass.resolve().firstField {
-                                    type = CommentClass.name
-                                }.self.also {
-                                    commentActionParamsClassCommentField = it
-                                }
-                            }.onFailure {
-                                YLog.error("$TAG: Failed to find Comment field in CommentActionParams: ${it.message}")
-                            }.getOrNull()
-
-                            val comment = commentField?.get(commentActionParams) ?: run {
-                                YLog.debug("$TAG: Failed to get Comment from CommentActionParams")
-                                return@before
-                            }
-
-                            val emojiUrlList = getEmojiUrlListFromCommentOrNull(comment)?.takeIf {
-                                it.isNotEmpty()
-                            } ?: return@before
-
-                            YLog.warn("$TAG: Download Emoji Function is NOT IMPLEMENT yet, got ${emojiUrlList.size} emoji url(s)")
-                            return@before
-                        }
-                    }.result {
-                        onConductFailure { param, throwable ->
-                            YLog.error("$TAG: Error during download callback hook: ${throwable.message}")
-                            param.result = param.callOriginal()
-                        }
-                        onHookingFailure { throwable ->
-                            YLog.error("$TAG: Failed to install download callback hook: ${throwable.message}")
-                        }
-                        onHooked {
-                            YLog.info("$TAG: Download callback hook installed, emoji download function is active")
-                        }
-                    }
-                } ?: run {
-                    YLog.warn("$TAG: Target method not found, emoji download function is not active")
+                transaction.add(::installSaveEmojiCallbackHook.name) {
+                    installSaveEmojiCallbackHook(bridge)
                 }
+
+                transaction.commit()
             }
         }
     }
@@ -188,5 +66,155 @@ object CommentEmojiHooker : YukiBaseHooker() {
             @Suppress("UNCHECKED_CAST")
             (UrlModelClassUrlListField.get(animateUrl) as? List<String>)
         }.getOrNull()
+    }
+
+    private fun installSaveEmojiBtnHook(bridge: DexKitBridge): YukiMemberHookCreator.MemberHookCreator.Result? {
+        var ret: YukiMemberHookCreator.MemberHookCreator.Result? = null
+
+        // Force enable "Save to Album" button for emoji comments
+        bridge.findMethod {
+            matcher {
+                modifiers = Modifier.STATIC
+                params {
+                    add(CommentClass.name)
+                    add("int")
+                }
+                returnType = "boolean"
+                invokeMethods {
+                    // TODO: This method has already been looked up in CommentImageHooker, consider caching and sharing it here
+                    add {
+                        declaredClass = "com.ss.android.ugc.aweme.comment.model.CommentImageStruct"
+                        returnType = UrlModelClass.name
+                        paramCount = 0
+                        addUsingField {
+                            name = "downloadUrl"
+                        }
+                    }
+                }
+            }
+        }.singleOrNull()?.also { result ->
+            YLog.debug("$TAG: Target method found: ${result.className}.${result.methodName}")
+
+            result.className.toClass().resolve().firstMethod {
+                name = result.methodName
+            }.hook {
+                before {
+                    val comment = args[0] ?: return@before
+
+                    val emojiUrlList = getEmojiUrlListFromCommentOrNull(comment)
+                    if (emojiUrlList?.isNotEmpty() == true) {
+                        resultTrue()
+                    }
+                }
+            }.result {
+                onHookingFailure { throwable ->
+                    YLog.error("$TAG: Unable to replace with original emoji URL: ${throwable.message}")
+                }
+                onConductFailure { param, throwable ->
+                    YLog.error("$TAG: Error during download callback hook: ${throwable.message}")
+                    param.result = param.callOriginal()
+                }
+                onHooked {
+                    YLog.info("$TAG: Hook installed, 'Save to album' button will show for emoji comments")
+                }.also {
+                    ret = it
+                }
+            }
+        } ?: run {
+            YLog.warn("$TAG: Target method not found, save to album feature is not active")
+        }
+
+        return ret
+    }
+
+    private fun installSaveEmojiCallbackHook(bridge: DexKitBridge): YukiMemberHookCreator.MemberHookCreator.Result? {
+        var ret: YukiMemberHookCreator.MemberHookCreator.Result? = null
+
+        bridge.findMethod {
+            matcher {
+                modifiers = Modifier.STATIC + Modifier.FINAL + Modifier.PUBLIC
+                returnType = "java.lang.Object"
+                params {
+                    count = 1
+                }
+                addUsingString("bpea-comment_save_image_to_album")
+            }
+        }.singleOrNull()?.also { result ->
+            YLog.debug("$TAG: Target method found: ${result.className}.${result.methodName}")
+
+            result.className.toClass().resolve().firstMethod {
+                name = result.methodName
+            }.hook {
+                before {
+                    val cbkInstance = args[0] ?: run {
+                        YLog.debug("$TAG: Failed to extract cbkInstance from args")
+                        return@before
+                    }
+
+                    val saveImageActionItem = cbkInstance.asResolver().firstField {
+                        type = "java.lang.Object"
+                    }.get() ?: run {
+                        YLog.debug("$TAG: Failed to extract saveImageActionItem from args")
+                        return@before
+                    }
+
+                    val commentActionParamsField =
+                        saveImageActionItemClassCommentActionParamsField ?: runCatching {
+                            SaveImageActionItemClass.resolve().firstField {
+                                type = CommentActionParamsClass.name
+                            }.self.also {
+                                saveImageActionItemClassCommentActionParamsField = it
+                            }
+                        }.onFailure {
+                            YLog.error("$TAG: Failed to find CommentActionParams field in SaveImageActionItem: ${it.message}")
+                        }.getOrNull()
+
+                    val commentActionParams =
+                        commentActionParamsField?.get(saveImageActionItem) ?: run {
+                            YLog.debug("$TAG: Failed to get CommentActionParams from SaveImageActionItem")
+                            return@before
+                        }
+
+                    val commentField = commentActionParamsClassCommentField ?: runCatching {
+                        CommentActionParamsClass.resolve().firstField {
+                            type = CommentClass.name
+                        }.self.also {
+                            commentActionParamsClassCommentField = it
+                        }
+                    }.onFailure {
+                        YLog.error("$TAG: Failed to find Comment field in CommentActionParams: ${it.message}")
+                    }.getOrNull()
+
+                    val comment = commentField?.get(commentActionParams) ?: run {
+                        YLog.debug("$TAG: Failed to get Comment from CommentActionParams")
+                        return@before
+                    }
+
+                    val emojiUrlList = getEmojiUrlListFromCommentOrNull(comment)?.takeIf {
+                        it.isNotEmpty()
+                    } ?: return@before
+
+                    YLog.warn("$TAG: Download Emoji Function is NOT IMPLEMENT yet, got ${emojiUrlList.size} emoji url(s)")
+                    return@before
+                }
+            }.result {
+                onConductFailure { param, throwable ->
+                    YLog.error("$TAG: Error during download callback hook: ${throwable.message}")
+                    param.result = param.callOriginal()
+                }
+                onHookingFailure { throwable ->
+                    YLog.error("$TAG: Failed to install download callback hook: ${throwable.message}")
+                }
+                onHooked {
+                    YLog.info("$TAG: Download callback hook installed, emoji download function is active")
+                }.also {
+                    ret = it
+                }
+            }
+        } ?: run {
+            YLog.warn("$TAG: Target method not found, emoji download function is not active")
+        }
+
+        return ret
     }
 }

--- a/app/src/main/java/com/yst/mkga/hook/dy/hook/CommentEmojiHooker.kt
+++ b/app/src/main/java/com/yst/mkga/hook/dy/hook/CommentEmojiHooker.kt
@@ -41,7 +41,7 @@ object CommentEmojiHooker : YukiBaseHooker() {
     }
 
     override fun onHook() {
-        loadApp(name = "com.ss.android.ugc.aweme") {
+        withProcess(mainProcessName) {
             DexKitBridge.create(this.appInfo.sourceDir).use { bridge ->
                 // Force enable "Save to Album" button for emoji comments
                 bridge.findMethod {

--- a/app/src/main/java/com/yst/mkga/hook/dy/hook/CommentEmojiHooker.kt
+++ b/app/src/main/java/com/yst/mkga/hook/dy/hook/CommentEmojiHooker.kt
@@ -32,19 +32,20 @@ import com.yst.mkga.hook.dy.hook.utils.FileTypeDetector
 object CommentEmojiHooker : YukiBaseHooker() {
     private val TAG = this::class.simpleName
 
-    private val CommentClass by lazyClass("com.ss.android.ugc.aweme.comment.model.Comment")
-    private val EmojiClass by lazyClass("com.ss.android.ugc.aweme.emoji.model.Emoji")
-    private val UrlModelClass by lazyClass("com.ss.android.ugc.aweme.base.model.UrlModel")
-    private val SaveImageActionItemClass by lazyClass("com.ss.android.ugc.aweme.comment.manager.longclickaction.actions.SaveImageActionItem")
-    private val CommentActionParamsClass by lazyClass("com.ss.android.ugc.aweme.comment.CommentActionParams")
-    private val CommentLongPressItemModelClass by lazyClass("com.ss.android.ugc.aweme.comment.ui.longpress.CommentLongPressItemModel")
-    private val CommentImageStructClass by lazyClass("com.ss.android.ugc.aweme.comment.model.CommentImageStruct")
-    private val DownloadInfoClass by lazyClass("com.ss.android.socialbase.downloader.model.DownloadInfo")
-    private val UGFileUtilsKtClass by lazyClass("com.bytedance.android.ug.UGFileUtilsKt")
-    private val TokenCertClass by lazyClass("com.bytedance.bpea.cert.token.TokenCert")
-    private val DigestUtilsClass by lazyClass("com.bytedance.common.utility.DigestUtils")
     private val CmtImageProgressDownloadListenerClass by lazyClass("com.ss.android.ugc.aweme.comment.helper.download.CmtImageProgressDownloadListener")
+    // notify result (log tracing + show toast)
+    private val CmtImageProgressDownloadListenerClassNotifyResultMethod: Method by lazy {
+        CmtImageProgressDownloadListenerClass.resolve().firstMethod {
+            modifiers(Modifiers.PUBLIC, Modifiers.FINAL)
+            parameters(Context::class, Boolean::class)
+            parameterCount = 2
+        }.self.apply {
+            isAccessible = true
+        }
+    }
 
+    private val CommentClass by lazyClass("com.ss.android.ugc.aweme.comment.model.Comment")
+    // linked Emoji object
     private val CommentClassEmojiField: Field by lazy {
         CommentClass.resolve().firstField {
             name = "emoji"
@@ -52,23 +53,7 @@ object CommentEmojiHooker : YukiBaseHooker() {
             isAccessible = true
         }
     }
-
-    private val EmojiClassAnimateUrlField: Field by lazy {
-        EmojiClass.resolve().firstField {
-            name = "animateUrl"
-        }.self.apply {
-            isAccessible = true
-        }
-    }
-
-    private val UrlModelClassUrlListField: Field by lazy {
-        UrlModelClass.resolve().firstField {
-            name = "urlList"
-        }.self.apply {
-            isAccessible = true
-        }
-    }
-
+    //comment image list (List<CommentImageStruct>)
     private val CommentClassImageListField: Field by lazy {
         CommentClass.resolve().firstField {
             name = "imageList"
@@ -77,6 +62,15 @@ object CommentEmojiHooker : YukiBaseHooker() {
         }
     }
 
+    private val CommentActionParamsClass by lazyClass("com.ss.android.ugc.aweme.comment.CommentActionParams")
+    // the associated Comment
+    private var commentActionParamsClassCommentField: Field? = null
+    // current image index (int)
+    private var commentActionParamsClassImageIndexField: Field? = null
+
+    // comment image data
+    private val CommentImageStructClass by lazyClass("com.ss.android.ugc.aweme.comment.model.CommentImageStruct")
+    // image download URL (UrlModel)
     private val CommentImageStructClassDownloadUrlField: Field by lazy {
         CommentImageStructClass.resolve().firstField {
             name = "downloadUrl"
@@ -85,6 +79,65 @@ object CommentEmojiHooker : YukiBaseHooker() {
         }
     }
 
+    private val CommentLongPressItemModelClass by lazyClass("com.ss.android.ugc.aweme.comment.ui.longpress.CommentLongPressItemModel")
+    // CommentActionParams carried by the menu item
+    private var commentLongPressItemModelClassCommentActionParamsField: Field? = null
+
+    private val DigestUtilsClass by lazyClass("com.bytedance.common.utility.DigestUtils")
+    // md5Hex(String): String
+    private val DigestUtilsClassMd5HexMethod: Method by lazy {
+        DigestUtilsClass.resolve().firstMethod {
+            name = "md5Hex"
+            returnType = String::class
+            modifiers(Modifiers.PUBLIC, Modifiers.STATIC)
+            parameters(String::class)
+            parameterCount = 1
+        }.self.apply {
+            isAccessible = true
+        }
+    }
+
+    private val DownloadInfoClass by lazyClass("com.ss.android.socialbase.downloader.model.DownloadInfo")
+    // url: download URL
+    private val downloadInfoClassUrlField: Field by lazy {
+        DownloadInfoClass.resolve().firstField {
+            name = "url"
+        }.self.apply {
+            isAccessible = true
+        }
+    }
+    // getTargetFilePath(): String
+    private val downloadInfoClassGetTargetFilePathMethod: Method by lazy {
+        DownloadInfoClass.resolve().firstMethod {
+            name = "getTargetFilePath"
+        }.self.apply {
+            isAccessible = true
+        }
+    }
+
+    private val EmojiClass by lazyClass("com.ss.android.ugc.aweme.emoji.model.Emoji")
+    // animateUrl: animated emoji URL
+    private val EmojiClassAnimateUrlField: Field by lazy {
+        EmojiClass.resolve().firstField {
+            name = "animateUrl"
+        }.self.apply {
+            isAccessible = true
+        }
+    }
+
+    // save-image long-press action
+    private val SaveImageActionItemClass by lazyClass("com.ss.android.ugc.aweme.comment.manager.longclickaction.actions.SaveImageActionItem")
+    // CommentActionParams carried by the action item
+    private var saveImageActionItemClassCommentActionParamsField: Field? = null
+
+    // BPEA cert token for media store auth
+    private val TokenCertClass by lazyClass("com.bytedance.bpea.cert.token.TokenCert")
+    private val commentSaveTokenCert by lazy {
+        TokenCertClass.getConstructor(String::class.java).newInstance("bpea-comment_save_image_to_album")
+    }
+
+    // file utility extension functions
+    private val UGFileUtilsKtClass by lazyClass("com.bytedance.android.ug.UGFileUtilsKt")
     private val UGFileUtilsKtClassCopyFileMethod: Method by lazy {
         UGFileUtilsKtClass.resolve().firstMethod {
             name = "copyFile"
@@ -96,19 +149,7 @@ object CommentEmojiHooker : YukiBaseHooker() {
             isAccessible = true
         }
     }
-
-    private val UGFileUtilsKtClassRemoveFileMethod: Method by lazy {
-        UGFileUtilsKtClass.resolve().firstMethod {
-            name = "removeFile"
-            returnType = Boolean::class
-            modifiers(Modifiers.PUBLIC, Modifiers.STATIC, Modifiers.FINAL)
-            parameters(String::class, String::class)
-            parameterCount = 2
-        }.self.apply {
-            isAccessible = true
-        }
-    }
-
+    // get internal storage dir
     private val UGFileUtilsKtClassGetStorageDirMethod: Method by lazy {
         UGFileUtilsKtClass.resolve().firstMethod {
             name = "getStorageDir"
@@ -120,7 +161,7 @@ object CommentEmojiHooker : YukiBaseHooker() {
             isAccessible = true
         }
     }
-
+    // get external album dir
     private val UGFileUtilsKtClassGetExternalStorageDirectoryMethod: Method by lazy {
         UGFileUtilsKtClass.resolve().firstMethod {
             name = "getExternalStorageDirectory"
@@ -132,7 +173,7 @@ object CommentEmojiHooker : YukiBaseHooker() {
             isAccessible = true
         }
     }
-
+    // create media store URI
     private val UGFileUtilsKtClassGetImageUriMethod: Method by lazy {
         UGFileUtilsKtClass.resolve().firstMethod {
             name = "getImageUri"
@@ -150,7 +191,6 @@ object CommentEmojiHooker : YukiBaseHooker() {
             isAccessible = true
         }
     }
-
     private val UGFileUtilsClassContextField: Field by lazy {
         UGFileUtilsKtClass.resolve().firstField {
             name = "context"
@@ -159,52 +199,12 @@ object CommentEmojiHooker : YukiBaseHooker() {
         }
     }
 
-    private val DigestUtilsClassMd5HexMethod: Method by lazy {
-        DigestUtilsClass.resolve().firstMethod {
-            name = "md5Hex"
-            returnType = String::class
-            modifiers(Modifiers.PUBLIC, Modifiers.STATIC)
-            parameters(String::class)
-            parameterCount = 1
-        }.self.apply {
-            isAccessible = true
-        }
-    }
-
-    private val CmtImageProgressDownloadListenerClassReportDownloadRetMethod: Method by lazy {
-        CmtImageProgressDownloadListenerClass.resolve().firstMethod {
-            modifiers(Modifiers.PUBLIC, Modifiers.FINAL)
-            parameters(Context::class, Boolean::class)
-            parameterCount = 2
-        }.self.apply {
-            isAccessible = true
-        }
-    }
-
-    private var commentActionParamsClassCommentField: Field? = null
-    private var commentActionParamsClassImageIndexField: Field? = null
-    private var commentLongPressItemModelClassCommentActionParamsField: Field? = null
-    private var saveImageActionItemClassCommentActionParamsField: Field? = null
-
-    private val downloadInfoClassUrlField: Field by lazy {
-        DownloadInfoClass.resolve().firstField {
-            name = "url"
-        }.self.apply {
-            isAccessible = true
-        }
-    }
-
-    private val downloadInfoClassSavePathField: Field by lazy {
-        DownloadInfoClass.resolve().firstField {
-            name = "savePath"
-        }.self.apply {
-            isAccessible = true
-        }
-    }
-
-    private val downloadInfoClassGetTargetFilePathMethod: Method by lazy {
-        DownloadInfoClass.resolve().firstMethod {
-            name = "getTargetFilePath"
+    // URL list model with multiple CDN URLs
+    private val UrlModelClass by lazyClass("com.ss.android.ugc.aweme.base.model.UrlModel")
+    // download URL list ( List<String> )
+    private val UrlModelClassUrlListField: Field by lazy {
+        UrlModelClass.resolve().firstField {
+            name = "urlList"
         }.self.apply {
             isAccessible = true
         }
@@ -214,23 +214,367 @@ object CommentEmojiHooker : YukiBaseHooker() {
         withProcess(mainProcessName) {
             val transaction = HookTransaction(TAG)
             DexKitBridge.create(this.appInfo.sourceDir).use { bridge ->
+                // Force "save to album" button visible for emoji comments.
                 transaction.add(::installSaveEmojiToAlbumButtonHook.name) {
                     installSaveEmojiToAlbumButtonHook(bridge)
                 }
+                // Before the save button's download callback fires, inject emoji URLs into
+                // comment.imageList[0].downloadUrl so the downloader picks them up.
+                // Without it: the downloader fetches nothing because imageList is empty.
                 transaction.add(::installClickSaveEmojiToAlbumButtonCallbackHook.name) {
                     installClickSaveEmojiToAlbumButtonCallbackHook(bridge)
                 }
-                transaction.add(::installCreateGifUrihook.name) {
-                    installCreateGifUrihook(bridge)
-                }
+                // Intercept emoji download completion: detect real file type, convert video
+                // to GIF if needed, copy to album, show result toast, skip original handler
+                // — otherwise every downloaded emoji is saved as .png with MIME image/png.
                 transaction.add(::installEmojiDownloadedCallbackHook.name) {
                     installEmojiDownloadedCallbackHook(bridge)
+                }
+                // Fix MediaStore URI creation for converted GIF files: internal logic has a
+                // file-extension whitelist, so non-whitelisted extensions (e.g. gif) fail
+                // createUri and cannot be saved to external storage — this hook falls back
+                // to getImageUri manually and writes into output array.
+                transaction.add(::installCreateUriHook.name) {
+                    installCreateUriHook(bridge)
                 }
                 transaction.commit()
             }
         }
     }
 
+    private fun installSaveEmojiToAlbumButtonHook(bridge: DexKitBridge): YukiMemberHookCreator.MemberHookCreator.Result? {
+        var ret: YukiMemberHookCreator.MemberHookCreator.Result? = null
+
+        bridge.findMethod {
+            matcher {
+                modifiers = Modifier.STATIC
+                params {
+                    add(CommentClass.name)
+                    add("int")
+                }
+                returnType = "boolean"
+                invokeMethods {
+                    add {
+                        declaredClass = CommentImageStructClass.name
+                        returnType = UrlModelClass.name
+                        paramCount = 0
+                        addUsingField {
+                            name = "downloadUrl"
+                        }
+                    }
+                }
+            }
+        }.singleOrNull()?.also { result ->
+            YLog.info("$TAG: Target method found: ${result.className}.${result.methodName}")
+
+            result.className.toClass().resolve().firstMethod { name = result.methodName }.hook {
+                before {
+                    val comment = args[0] ?: return@before
+                    val emojiUrls = extractEmojiUrls(comment)
+                    if (!emojiUrls.isNullOrEmpty()) {
+                        // force the visibility check to return true — show save button
+                        resultTrue()
+                    }
+                }
+            }.result {
+                onConductFailure { param, throwable ->
+                    YLog.error("$TAG: Save emoji button hook runtime error", throwable)
+                }
+                onHookingFailure { throwable ->
+                    YLog.error("$TAG: Failed to hook save emoji button", throwable)
+                }
+                onHooked {
+                    YLog.info("$TAG: Save emoji button hook installed successfully. The button will be shown for emoji comments")
+                }.also {
+                    ret = it
+                }
+            }
+        } ?: run {
+            YLog.error("$TAG: Target method not found, save emoji to album button will not be shown")
+        }
+        return ret
+    }
+
+    private fun installClickSaveEmojiToAlbumButtonCallbackHook(bridge: DexKitBridge): YukiMemberHookCreator.MemberHookCreator.Result? {
+        var ret: YukiMemberHookCreator.MemberHookCreator.Result? = null
+
+        bridge.findMethod {
+            matcher {
+                modifiers = Modifier.STATIC + Modifier.FINAL + Modifier.PUBLIC
+                returnType = "java.lang.Object"
+                params {
+                    count = 1
+                }
+                addUsingString("bpea-comment_save_image_to_album")
+            }
+        }.singleOrNull()?.also { result ->
+            YLog.info("$TAG: Target method found: ${result.className}.${result.methodName}")
+
+            result.className.toClass().resolve().firstMethod { name = result.methodName }.hook {
+                var savedComment: Any? = null
+                var savedActionItem: Any? = null
+                var originImageUrlList: List<*>? = null
+                var originImageIndex = -1
+                before {
+                    val cbkInstance = args[0] ?: return@before
+
+                    val actionItem = cbkInstance.asResolver().firstField {
+                        type = Object::class
+                    }.get() ?: return@before
+
+                    val comment = extractComment(actionItem) ?: return@before
+                    val emojiUrls = extractEmojiUrls(comment) ?: return@before
+
+                    // temporarily install emoji URLs so the downloader sees them
+                    // save original state to be restored in after{}
+                    originImageUrlList = CommentClassImageListField.get(comment) as? List<*>
+                    originImageIndex = overrideImageIndex(actionItem, 0) // target the first (just-injected) image
+                    savedActionItem = actionItem
+                    savedComment = comment
+
+                    injectEmojiUrls(comment, emojiUrls, prepend = true)
+
+                    YLog.debug( "$TAG: Injected ${emojiUrls.size} emoji url(s) into comment")
+                }
+                // undo temporary edits — restore comment.imageList and actionItem.imageIndex
+                after {
+                    savedComment?.let { c ->
+                        CommentClassImageListField.set(c, originImageUrlList)
+                        if (originImageIndex >= 0) {
+                            savedActionItem?.let {
+                                overrideImageIndex(it, originImageIndex)
+                            }
+                        }
+                    }
+                    savedComment = null
+                    savedActionItem = null
+                    originImageUrlList = null
+                    originImageIndex = -1
+                }
+            }.result {
+                onConductFailure { param, throwable ->
+                    YLog.error("$TAG: Download callback hook runtime error", throwable)
+                }
+                onHookingFailure { throwable ->
+                    YLog.error("$TAG: Failed to hook download callback", throwable)
+                }
+                onHooked {
+                    YLog.info("$TAG: Download callback hook installed successfully. Emoji URLs will be injected when saving")
+                }.also {
+                    ret = it
+                }
+            }
+        } ?: run {
+            YLog.warn("$TAG: Target method not found, download callback hook will not be installed")
+        }
+
+        return ret
+    }
+
+    private fun installEmojiDownloadedCallbackHook(bridge: DexKitBridge): YukiMemberHookCreator.MemberHookCreator.Result? {
+        var ret: YukiMemberHookCreator.MemberHookCreator.Result? = null
+
+        bridge.findMethod {
+            matcher {
+                name = "onSuccessed"
+                modifiers = Modifier.FINAL + Modifier.PUBLIC
+                returnType = "void"
+                params {
+                    add("com.ss.android.socialbase.downloader.model.DownloadInfo")
+                }
+                usingStrings {
+                    add("/douyin/comment")
+                    add("comment_")
+                }
+                invokeMethods {
+                    add {
+                        descriptor =
+                            "Lcom/bytedance/android/ug/UGFileUtilsKt;->copyFile(Ljava/lang/String;Ljava/lang/String;Lcom/bytedance/bpea/cert/token/TokenCert;)Z"
+                    }
+                }
+            }
+        }.singleOrNull()?.also { match ->
+            YLog.info("$TAG: Target method found: ${match.className}.${match.methodName}")
+
+            match.className.toClass().resolve().firstMethod {
+                name = match.methodName
+            }.hook {
+                before {
+                    val downloadInfo = args[0] ?: return@before
+
+                    val dlUrl =
+                        downloadInfoClassUrlField.get(downloadInfo) as? String ?: return@before
+                    // Emoji animateUrl file extension is always .heif
+                    if (!dlUrl.contains(".heif")) {
+                        return@before
+                    }
+
+                    // Downloaded file save path
+                    val sourcePath =
+                        downloadInfoClassGetTargetFilePathMethod.invoke(downloadInfo) as? String
+                            ?: return@before
+                    val sourceMimeType = FileTypeDetector.detect(sourcePath).mimeType
+                    YLog.info("$TAG: Source MIME type: $sourceMimeType")
+
+                    val saveFilePrefix = "comment_${
+                        DigestUtilsClassMd5HexMethod.invoke(
+                            null,
+                            dlUrl + System.currentTimeMillis().toString()
+                        ) as String?
+                    }"
+
+                    // Prepare file to save
+                    var fileToSave = sourcePath
+                    var saveFileExt = MimeTypeMap.getSingleton()
+                        .getExtensionFromMimeType(sourceMimeType)
+                        ?: sourcePath.substringAfterLast('.', "")
+                    var hasTempFile = false
+
+                    // Convert video source to GIF animation
+                    if (sourceMimeType.startsWith("video/")) {
+                        YLog.info("$TAG: Source MIME type is video, converting to GIF")
+
+                        val gifTempPath = "${
+                            UGFileUtilsKtClassGetStorageDirMethod.invoke(
+                                null,
+                                "/comment/images",
+                                false
+                            ) as String
+                        }${File.separator}${saveFilePrefix}.gif"
+
+                        if (convertMedia2Gif(sourcePath, gifTempPath)) {
+                            fileToSave = gifTempPath
+                            saveFileExt = "gif"
+                            hasTempFile = true
+                        } else {
+                            YLog.error("$TAG: Convert video to GIF failed, fallback to direct copy")
+                        }
+                    }
+
+                    // Copy to album
+                    val saveFilePath = "${
+                        UGFileUtilsKtClassGetExternalStorageDirectoryMethod.invoke(
+                            null,
+                            "/douyin/comment",
+                            false
+                        ) as String
+                    }${File.separator}${saveFilePrefix}.${saveFileExt}"
+
+                    val cpRet = UGFileUtilsKtClassCopyFileMethod.invoke(
+                        null,
+                        fileToSave,
+                        saveFilePath,
+                        commentSaveTokenCert
+                    ) as Boolean
+
+                    // shows success dialog
+                    val context =
+                        instance.asResolver().firstField().get()?.asResolver()?.firstField {
+                            type = Context::class
+                        }?.get<Context?>()
+
+                    CmtImageProgressDownloadListenerClassNotifyResultMethod.invoke(
+                        instance,
+                        context,
+                        cpRet
+                    )
+
+                    if (hasTempFile) {
+                        File(fileToSave).delete()
+                    }
+
+                    // Return null to skip original method execution
+                    resultNull()
+                }
+            }.result {
+                onConductFailure { param, throwable ->
+                    YLog.error("$TAG: Emoji download completion callback runtime error", throwable)
+                }
+                onHookingFailure { throwable ->
+                    YLog.error("$TAG: Failed to hook emoji download completion callback", throwable)
+                }
+                onHooked {
+                    YLog.info("$TAG: Emoji download completion callback hooked")
+                }.also {
+                    ret = it
+                }
+            }
+        } ?: run {
+            YLog.warn("$TAG: Target method not found, emoji download completion callback will not be installed")
+        }
+
+        return ret
+    }
+
+    @Suppress("UNUSED_PARAMETER")
+    private fun installCreateUriHook(unused: DexKitBridge): YukiMemberHookCreator.MemberHookCreator.Result? {
+        var ret: YukiMemberHookCreator.MemberHookCreator.Result? = null
+
+        UGFileUtilsKtClass.resolve().firstMethod {
+            name = "createUri"
+            returnType = android.net.Uri::class
+            modifiers(Modifiers.PUBLIC, Modifiers.STATIC, Modifiers.FINAL)
+            parameters(String::class, Boolean::class, Array<android.net.Uri>::class, TokenCertClass)
+            parameterCount = 4
+        }.hook {
+            after {
+                val uriRet = result as? android.net.Uri
+                // original createUri succeeded — nothing to fix
+                if (uriRet != null && uriRet != android.net.Uri.EMPTY) {
+                    return@after
+                }
+
+                // original createUri failed; build a URI manually via getImageUri
+                val filePath = args[0] as? String
+                if (filePath.isNullOrEmpty()) {
+                    return@after
+                }
+                val fileExt = filePath.substringAfterLast('.', "")
+                val fileMimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(fileExt) ?: return@after
+                val fileName = filePath.substring(filePath.lastIndexOf(File.separator) + 1)
+                // Ensure the virtual path has no leading '/' but strictly retains a trailing '/'.
+                val fileRelPath = filePath.substring(1, filePath.lastIndexOf(File.separator) + 1)
+
+                val context = UGFileUtilsClassContextField.get(null) as? Context ?: return@after
+                val tokenCert = args[3]
+
+                val finalUri = UGFileUtilsKtClassGetImageUriMethod.invoke(
+                    null,
+                    context,
+                    fileName,
+                    fileMimeType,
+                    fileRelPath,
+                    tokenCert
+                ) as? android.net.Uri ?: return@after
+                // replace the hook's return value with the URI we just created
+                result = finalUri
+                YLog.debug("$TAG: finalUri: $finalUri")
+
+                // also write into the caller's out-parameter array
+                @Suppress("UNCHECKED_CAST")
+                val uriArr = args[2] as? Array<android.net.Uri> ?: return@after
+                if (uriArr.isNotEmpty()) {
+                    uriArr[0] = finalUri
+                }
+            }
+        }.result {
+            onConductFailure { param, throwable ->
+                YLog.error("$TAG: createUri hook runtime error", throwable)
+            }
+            onHookingFailure { throwable ->
+                YLog.error("$TAG: Failed to hook createUri", throwable)
+            }
+            onHooked {
+                YLog.info("$TAG: createUri hooked. URI creation will be intercepted for emoji GIF conversion.")
+            }.also {
+                ret = it
+            }
+        }
+
+        return ret
+    }
+
+    // Gets CommentActionParams held by a long-press menu item
     private fun extractActionParams(actionItem: Any): Any? {
         val field = commentLongPressItemModelClassCommentActionParamsField
             ?: CommentLongPressItemModelClass.resolve()
@@ -243,6 +587,7 @@ object CommentEmojiHooker : YukiBaseHooker() {
         return field.get(actionItem)
     }
 
+    // Gets the Comment from a long-press menu item
     private fun extractComment(actionItem: Any): Any? {
         val params = extractActionParams(actionItem) ?: return null
         val field = commentActionParamsClassCommentField
@@ -253,6 +598,70 @@ object CommentEmojiHooker : YukiBaseHooker() {
                 commentActionParamsClassCommentField = it
             }
         return field.get(params)
+    }
+
+    // Gets emoji download URLs from comment.emoji.animateUrl.urlList
+    private fun extractEmojiUrls(comment: Any): List<String>? {
+        return runCatching {
+            val emoji = CommentClassEmojiField.get(comment) ?: return@runCatching null
+            val animateUrl = EmojiClassAnimateUrlField.get(emoji) ?: return@runCatching null
+            @Suppress("UNCHECKED_CAST")
+            UrlModelClassUrlListField.get(animateUrl) as? List<String>
+        }.getOrNull()
+    }
+
+    // Writes emoji URLs into comment.imageList[0].downloadUrl.urlList, optionally prepended to existing URLs
+    private fun injectEmojiUrls(comment: Any, emojiUrls: List<String>, prepend: Boolean = true) {
+        var imageList = CommentClassImageListField.get(comment) as? List<*>
+        if (imageList.isNullOrEmpty()) {
+            val newStruct = CommentImageStructClass.getConstructor().newInstance()
+            imageList = listOf(newStruct)
+            CommentClassImageListField.set(comment, imageList)
+        }
+
+        val targetStruct = imageList[0]
+        var urlModel = CommentImageStructClassDownloadUrlField.get(targetStruct)
+        if (urlModel == null) {
+            urlModel = UrlModelClass.getConstructor().newInstance()
+            CommentImageStructClassDownloadUrlField.set(targetStruct, urlModel)
+        }
+
+        var finalUrls: List<String>? = if (prepend) {
+            @Suppress("UNCHECKED_CAST")
+            val imageUrls = UrlModelClassUrlListField.get(urlModel) as? List<String>
+            if (imageUrls.isNullOrEmpty()) {
+                emojiUrls
+            } else {
+                emojiUrls + imageUrls
+            }
+        } else {
+            emojiUrls
+        }
+        UrlModelClassUrlListField.set(urlModel, finalUrls)
+    }
+
+    // Sets a new image index on the save-image action, returns the previous one
+    private fun overrideImageIndex(actionItem: Any, index: Int): Int {
+        val paramsField = saveImageActionItemClassCommentActionParamsField
+            ?: SaveImageActionItemClass.resolve().firstField {
+                type = CommentActionParamsClass.name
+            }.self.also {
+                it.isAccessible = true
+                saveImageActionItemClassCommentActionParamsField = it
+            }
+
+        val params = paramsField.get(actionItem) ?: return -1
+        val field = commentActionParamsClassImageIndexField
+            ?: CommentActionParamsClass.resolve().firstField {
+                type = Int::class
+            }.self.also {
+                it.isAccessible = true
+                commentActionParamsClassImageIndexField = it
+            }
+
+        val originImageIndex = field.get(params) as Int
+        field.set(params, index)
+        return originImageIndex
     }
 
     private fun convertMedia2Gif(mediaPath: String, gifPath: String): Boolean {
@@ -380,408 +789,5 @@ object CommentEmojiHooker : YukiBaseHooker() {
             } catch (e: Exception) {
             }
         }
-    }
-
-    private fun extractEmojiUrls(comment: Any): List<String>? {
-        return runCatching {
-            val emoji = CommentClassEmojiField.get(comment) ?: return@runCatching null
-            val animateUrl = EmojiClassAnimateUrlField.get(emoji) ?: return@runCatching null
-            @Suppress("UNCHECKED_CAST")
-            UrlModelClassUrlListField.get(animateUrl) as? List<String>
-        }.getOrNull()
-    }
-
-    private fun overrideImageIndex(actionItem: Any, index: Int): Int {
-        val paramsField = saveImageActionItemClassCommentActionParamsField
-            ?: SaveImageActionItemClass.resolve().firstField {
-                type = CommentActionParamsClass.name
-            }.self.also {
-                it.isAccessible = true
-                saveImageActionItemClassCommentActionParamsField = it
-            }
-
-        val params = paramsField.get(actionItem) ?: return -1
-        val field = commentActionParamsClassImageIndexField
-            ?: CommentActionParamsClass.resolve().firstField {
-                type = Int::class
-            }.self.also {
-                it.isAccessible = true
-                commentActionParamsClassImageIndexField = it
-            }
-
-        val originImageIndex = field.get(params) as Int
-        field.set(params, index)
-        return originImageIndex
-    }
-
-    private fun injectEmojiUrls(comment: Any, emojiUrls: List<String>, prepend: Boolean = true) {
-        var imageList = CommentClassImageListField.get(comment) as? List<*>
-        if (imageList.isNullOrEmpty()) {
-            val newStruct = CommentImageStructClass.getConstructor().newInstance()
-            imageList = listOf(newStruct)
-            CommentClassImageListField.set(comment, imageList)
-        }
-
-        val targetStruct = imageList[0]
-        var urlModel = CommentImageStructClassDownloadUrlField.get(targetStruct)
-        if (urlModel == null) {
-            urlModel = UrlModelClass.getConstructor().newInstance()
-            CommentImageStructClassDownloadUrlField.set(targetStruct, urlModel)
-        }
-
-        var finalUrls: List<String>? = if (prepend) {
-            @Suppress("UNCHECKED_CAST")
-            val imageUrls = UrlModelClassUrlListField.get(urlModel) as? List<String>
-            if (imageUrls.isNullOrEmpty()) {
-                emojiUrls
-            } else {
-                emojiUrls + imageUrls
-            }
-        } else {
-            emojiUrls
-        }
-        UrlModelClassUrlListField.set(urlModel, finalUrls)
-    }
-
-    private fun installSaveEmojiToAlbumButtonHook(bridge: DexKitBridge): YukiMemberHookCreator.MemberHookCreator.Result? {
-        var ret: YukiMemberHookCreator.MemberHookCreator.Result? = null
-
-        bridge.findMethod {
-            matcher {
-                modifiers = Modifier.STATIC
-                params {
-                    add(CommentClass.name)
-                    add("int")
-                }
-                returnType = "boolean"
-                invokeMethods {
-                    add {
-                        declaredClass = CommentImageStructClass.name
-                        returnType = UrlModelClass.name
-                        paramCount = 0
-                        addUsingField {
-                            name = "downloadUrl"
-                        }
-                    }
-                }
-            }
-        }.singleOrNull()?.also { result ->
-            YLog.debug("$TAG: Target method found: ${result.className}.${result.methodName}")
-
-            result.className.toClass().resolve().firstMethod { name = result.methodName }.hook {
-                before {
-                    val comment = args[0] ?: return@before
-                    val emojiUrls = extractEmojiUrls(comment)
-                    if (!emojiUrls.isNullOrEmpty()) {
-                        resultTrue()
-                    }
-                }
-            }.result {
-                onConductFailure { param, throwable ->
-                    YLog.error("$TAG: Save emoji button hook runtime error", throwable)
-                }
-                onHookingFailure { throwable ->
-                    YLog.error("$TAG: Failed to hook save emoji button", throwable)
-                }
-                onHooked {
-                    YLog.info("$TAG: Save emoji button hook installed successfully. The button will be shown for emoji comments")
-                }.also {
-                    ret = it
-                }
-            }
-        } ?: run {
-            YLog.warn("$TAG: Target method not found, save emoji to album button will not be shown")
-        }
-        return ret
-    }
-
-    private fun installClickSaveEmojiToAlbumButtonCallbackHook(bridge: DexKitBridge): YukiMemberHookCreator.MemberHookCreator.Result? {
-        var ret: YukiMemberHookCreator.MemberHookCreator.Result? = null
-
-        bridge.findMethod {
-            matcher {
-                modifiers = Modifier.STATIC + Modifier.FINAL + Modifier.PUBLIC
-                returnType = "java.lang.Object"
-                params {
-                    count = 1
-                }
-                addUsingString("bpea-comment_save_image_to_album")
-            }
-        }.singleOrNull()?.also { result ->
-            YLog.debug("$TAG: Target method found: ${result.className}.${result.methodName}")
-
-            result.className.toClass().resolve().firstMethod { name = result.methodName }.hook {
-                var savedComment: Any? = null
-                var savedActionItem: Any? = null
-                var originImageUrlList: List<*>? = null
-                var originImageIndex = -1
-                before {
-                    val cbkInstance = args[0] ?: return@before
-
-                    val actionItem = cbkInstance.asResolver().firstField {
-                        type = Object::class
-                    }.get() ?: return@before
-
-                    val comment = extractComment(actionItem) ?: return@before
-                    val emojiUrls = extractEmojiUrls(comment) ?: return@before
-
-                    // store original state for after
-                    originImageUrlList = CommentClassImageListField.get(comment) as? List<*>
-                    originImageIndex = overrideImageIndex(actionItem, 0)
-                    savedActionItem = actionItem
-                    savedComment = comment
-
-                    injectEmojiUrls(comment, emojiUrls, prepend = true)
-
-                    YLog.debug(
-                        "$TAG: Injected ${emojiUrls.size} emoji url(s) into comment, emoji url list[0]: ${
-                            emojiUrls.getOrNull(
-                                0
-                            ) ?: "null"
-                        }"
-                    )
-
-                    YLog.warn("$TAG: HEIF to GIF conversion not yet implemented, saved file may not be viewable in gallery")
-                }
-                after {
-                    savedComment?.let { c ->
-                        CommentClassImageListField.set(c, originImageUrlList)
-                        if (originImageIndex >= 0) {
-                            savedActionItem?.let {
-                                overrideImageIndex(it, originImageIndex)
-                            }
-                        }
-                    }
-                    savedComment = null
-                    savedActionItem = null
-                    originImageUrlList = null
-                    originImageIndex = -1
-                }
-            }.result {
-                onConductFailure { param, throwable ->
-                    YLog.error("$TAG: Download callback hook runtime error", throwable)
-                }
-                onHookingFailure { throwable ->
-                    YLog.error("$TAG: Failed to hook download callback", throwable)
-                }
-                onHooked {
-                    YLog.info("$TAG: Download callback hook installed successfully. Emoji URLs will be injected when saving")
-                }.also {
-                    ret = it
-                }
-            }
-        } ?: run {
-            YLog.warn("$TAG: Target method not found, download callback hook will not be installed")
-        }
-
-        return ret
-    }
-
-    private fun installEmojiDownloadedCallbackHook(bridge: DexKitBridge): YukiMemberHookCreator.MemberHookCreator.Result? {
-        var ret: YukiMemberHookCreator.MemberHookCreator.Result? = null
-
-        bridge.findMethod {
-            matcher {
-                name = "onSuccessed"
-                modifiers = Modifier.FINAL + Modifier.PUBLIC
-                returnType = "void"
-                params {
-                    add("com.ss.android.socialbase.downloader.model.DownloadInfo")
-                }
-                usingStrings {
-                    add("/douyin/comment")
-                    add("comment_")
-                }
-                invokeMethods {
-                    add {
-                        descriptor =
-                            "Lcom/bytedance/android/ug/UGFileUtilsKt;->copyFile(Ljava/lang/String;Ljava/lang/String;Lcom/bytedance/bpea/cert/token/TokenCert;)Z"
-                    }
-                }
-            }
-        }.singleOrNull()?.also { match ->
-            YLog.debug("$TAG: Target method found: ${match.className}.${match.methodName}")
-
-            match.className.toClass().resolve().firstMethod {
-                name = match.methodName
-            }.hook {
-                before {
-                    val downloadInfo = args[0] ?: return@before
-
-                    val dlUrl =
-                        downloadInfoClassUrlField.get(downloadInfo) as? String ?: return@before
-
-                    if (!dlUrl.contains(".heif")) {
-                        return@before
-                    }
-
-                    val sourcePath =
-                        downloadInfoClassGetTargetFilePathMethod.invoke(downloadInfo) as? String
-                            ?: return@before
-                    YLog.debug("$TAG: Source path: $sourcePath")
-
-                    val saveFileMimeType = FileTypeDetector.detect(sourcePath).mimeType
-                    YLog.debug("$TAG: Save file mime type: $saveFileMimeType")
-
-                    val saveFilePrefix = "comment_${
-                        DigestUtilsClassMd5HexMethod.invoke(
-                            null,
-                            dlUrl + System.currentTimeMillis().toString()
-                        ) as String?
-                    }"
-
-                    var cpRet: Boolean? = null
-                    if (saveFileMimeType.startsWith("video/")) {
-                        val saveFileName = "${saveFilePrefix}.gif"
-                        val saveFilePath = "${
-                            UGFileUtilsKtClassGetExternalStorageDirectoryMethod.invoke(
-                                null,
-                                "/douyin/comment",
-                                false
-                            ) as String
-                        }${File.separator}${saveFileName}"
-                        YLog.debug("$TAG: GIF save path: $saveFilePath")
-
-                        val gifTempPath = "${
-                            UGFileUtilsKtClassGetStorageDirMethod.invoke(
-                                null,
-                                "/comment/images",
-                                false
-                            ) as String
-                        }${File.separator}${saveFileName}"
-                        YLog.debug("$TAG: GIF temp path: $gifTempPath")
-
-                        if (!convertMedia2Gif(sourcePath, gifTempPath)) {
-                            YLog.error("$TAG: Convert HEIF To GIF failed")
-                            return@before
-                        }
-
-                        cpRet = UGFileUtilsKtClassCopyFileMethod.invoke(
-                            null,
-                            gifTempPath,
-                            saveFilePath,
-                            TokenCertClass.getConstructor(String::class.java)
-                                .newInstance("bpea-comment_save_image_to_album")
-                        ) as Boolean
-
-                        File(gifTempPath).delete()
-                    } else {
-                        val saveFileExt = MimeTypeMap.getSingleton().getExtensionFromMimeType(saveFileMimeType)
-                            ?: sourcePath.substringAfterLast('.', "")
-                        val saveFileName = "${saveFilePrefix}.${saveFileExt}"
-                        val saveFilePath = "${
-                            UGFileUtilsKtClassGetExternalStorageDirectoryMethod.invoke(
-                                null,
-                                "/douyin/comment",
-                                false
-                            ) as String
-                        }${File.separator}${saveFileName}"
-
-                        cpRet = UGFileUtilsKtClassCopyFileMethod.invoke(
-                            null,
-                            sourcePath,
-                            saveFilePath,
-                            TokenCertClass.getConstructor(String::class.java)
-                                .newInstance("bpea-comment_save_image_to_album")
-                        ) as Boolean
-                    }
-
-                    val context =
-                        instance.asResolver().firstField().get()?.asResolver()?.firstField {
-                            type = Context::class
-                        }?.get<Context?>()
-
-                    YLog.debug("$TAG: cpRet: $cpRet")
-                    CmtImageProgressDownloadListenerClassReportDownloadRetMethod.invoke(
-                        instance,
-                        context,
-                        cpRet
-                    )
-
-                    resultNull()
-                }
-            }.result {
-                onConductFailure { param, throwable ->
-                    YLog.error("$TAG: Emoji download completion callback runtime error", throwable)
-                }
-                onHookingFailure { throwable ->
-                    YLog.error("$TAG: Failed to hook emoji download completion callback", throwable)
-                }
-                onHooked {
-                    YLog.info("$TAG: Emoji download completion callback hooked. Emoji will be converted to GIF before saving to album.")
-                }.also {
-                    ret = it
-                }
-            }
-        } ?: run {
-            YLog.warn("$TAG: Target method not found, emoji save completion callback will not be installed")
-        }
-
-        return ret
-    }
-
-    @Suppress("UNUSED_PARAMETER")
-    private fun installCreateGifUrihook(unused: DexKitBridge): YukiMemberHookCreator.MemberHookCreator.Result? {
-        var ret: YukiMemberHookCreator.MemberHookCreator.Result? = null
-
-        UGFileUtilsKtClass.resolve().firstMethod {
-            name = "createUri"
-            returnType = android.net.Uri::class
-            modifiers(Modifiers.PUBLIC, Modifiers.STATIC, Modifiers.FINAL)
-            parameters(String::class, Boolean::class, Array<android.net.Uri>::class, TokenCertClass)
-            parameterCount = 4
-        }.hook {
-            after {
-                val uriRet = result as? android.net.Uri
-                if (uriRet != null && uriRet != android.net.Uri.EMPTY) {
-                    return@after
-                }
-
-                val filePath = args[0] as? String
-                if (filePath.isNullOrEmpty()) {
-                    return@after
-                }
-
-                val fileExt = filePath.substringAfterLast('.', "")
-                val fileMimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(fileExt) ?: return@after
-
-                val context = UGFileUtilsClassContextField.get(null) as? Context ?: return@after
-                val fileName = filePath.substring(filePath.lastIndexOf(File.separator) + 1)
-                val fileRelPath = filePath.substring(1, filePath.lastIndexOf(File.separator) + 1)
-                val tokenCert = args[3]
-
-                val finalUri = UGFileUtilsKtClassGetImageUriMethod.invoke(
-                    null,
-                    context,
-                    fileName,
-                    fileMimeType,
-                    fileRelPath,
-                    tokenCert
-                ) as? android.net.Uri ?: return@after
-                result = finalUri
-                YLog.debug("$TAG: finalUri: $finalUri")
-
-                @Suppress("UNCHECKED_CAST")
-                val uriArr = args[2] as? Array<android.net.Uri> ?: return@after
-
-                if (uriArr.isNotEmpty()) {
-                    uriArr[0] = finalUri
-                }
-            }
-        }.result {
-            onConductFailure { param, throwable ->
-                YLog.error("$TAG: createUri hook runtime error", throwable)
-            }
-            onHookingFailure { throwable ->
-                YLog.error("$TAG: Failed to hook createUri", throwable)
-            }
-            onHooked {
-                YLog.info("$TAG: createUri hooked. URI creation will be intercepted for emoji GIF conversion.")
-            }.also {
-                ret = it
-            }
-        }
-
-        return ret
     }
 }

--- a/app/src/main/java/com/yst/mkga/hook/dy/hook/CommentEmojiHooker.kt
+++ b/app/src/main/java/com/yst/mkga/hook/dy/hook/CommentEmojiHooker.kt
@@ -33,6 +33,7 @@ object CommentEmojiHooker : YukiBaseHooker() {
     private val TAG = this::class.simpleName
 
     private val CmtImageProgressDownloadListenerClass by lazyClass("com.ss.android.ugc.aweme.comment.helper.download.CmtImageProgressDownloadListener")
+
     // notify result (log tracing + show toast)
     private val CmtImageProgressDownloadListenerClassNotifyResultMethod: Method by lazy {
         CmtImageProgressDownloadListenerClass.resolve().firstMethod {
@@ -45,6 +46,7 @@ object CommentEmojiHooker : YukiBaseHooker() {
     }
 
     private val CommentClass by lazyClass("com.ss.android.ugc.aweme.comment.model.Comment")
+
     // linked Emoji object
     private val CommentClassEmojiField: Field by lazy {
         CommentClass.resolve().firstField {
@@ -53,6 +55,7 @@ object CommentEmojiHooker : YukiBaseHooker() {
             isAccessible = true
         }
     }
+
     //comment image list (List<CommentImageStruct>)
     private val CommentClassImageListField: Field by lazy {
         CommentClass.resolve().firstField {
@@ -63,13 +66,16 @@ object CommentEmojiHooker : YukiBaseHooker() {
     }
 
     private val CommentActionParamsClass by lazyClass("com.ss.android.ugc.aweme.comment.CommentActionParams")
+
     // the associated Comment
     private var commentActionParamsClassCommentField: Field? = null
+
     // current image index (int)
     private var commentActionParamsClassImageIndexField: Field? = null
 
     // comment image data
     private val CommentImageStructClass by lazyClass("com.ss.android.ugc.aweme.comment.model.CommentImageStruct")
+
     // image download URL (UrlModel)
     private val CommentImageStructClassDownloadUrlField: Field by lazy {
         CommentImageStructClass.resolve().firstField {
@@ -80,10 +86,12 @@ object CommentEmojiHooker : YukiBaseHooker() {
     }
 
     private val CommentLongPressItemModelClass by lazyClass("com.ss.android.ugc.aweme.comment.ui.longpress.CommentLongPressItemModel")
+
     // CommentActionParams carried by the menu item
     private var commentLongPressItemModelClassCommentActionParamsField: Field? = null
 
     private val DigestUtilsClass by lazyClass("com.bytedance.common.utility.DigestUtils")
+
     // md5Hex(String): String
     private val DigestUtilsClassMd5HexMethod: Method by lazy {
         DigestUtilsClass.resolve().firstMethod {
@@ -98,6 +106,7 @@ object CommentEmojiHooker : YukiBaseHooker() {
     }
 
     private val DownloadInfoClass by lazyClass("com.ss.android.socialbase.downloader.model.DownloadInfo")
+
     // url: download URL
     private val downloadInfoClassUrlField: Field by lazy {
         DownloadInfoClass.resolve().firstField {
@@ -106,6 +115,7 @@ object CommentEmojiHooker : YukiBaseHooker() {
             isAccessible = true
         }
     }
+
     // getTargetFilePath(): String
     private val downloadInfoClassGetTargetFilePathMethod: Method by lazy {
         DownloadInfoClass.resolve().firstMethod {
@@ -116,6 +126,7 @@ object CommentEmojiHooker : YukiBaseHooker() {
     }
 
     private val EmojiClass by lazyClass("com.ss.android.ugc.aweme.emoji.model.Emoji")
+
     // animateUrl: animated emoji URL
     private val EmojiClassAnimateUrlField: Field by lazy {
         EmojiClass.resolve().firstField {
@@ -127,6 +138,7 @@ object CommentEmojiHooker : YukiBaseHooker() {
 
     // save-image long-press action
     private val SaveImageActionItemClass by lazyClass("com.ss.android.ugc.aweme.comment.manager.longclickaction.actions.SaveImageActionItem")
+
     // CommentActionParams carried by the action item
     private var saveImageActionItemClassCommentActionParamsField: Field? = null
 
@@ -149,6 +161,7 @@ object CommentEmojiHooker : YukiBaseHooker() {
             isAccessible = true
         }
     }
+
     // get internal storage dir
     private val UGFileUtilsKtClassGetStorageDirMethod: Method by lazy {
         UGFileUtilsKtClass.resolve().firstMethod {
@@ -161,6 +174,7 @@ object CommentEmojiHooker : YukiBaseHooker() {
             isAccessible = true
         }
     }
+
     // get external album dir
     private val UGFileUtilsKtClassGetExternalStorageDirectoryMethod: Method by lazy {
         UGFileUtilsKtClass.resolve().firstMethod {
@@ -173,6 +187,7 @@ object CommentEmojiHooker : YukiBaseHooker() {
             isAccessible = true
         }
     }
+
     // create media store URI
     private val UGFileUtilsKtClassGetImageUriMethod: Method by lazy {
         UGFileUtilsKtClass.resolve().firstMethod {
@@ -201,6 +216,7 @@ object CommentEmojiHooker : YukiBaseHooker() {
 
     // URL list model with multiple CDN URLs
     private val UrlModelClass by lazyClass("com.ss.android.ugc.aweme.base.model.UrlModel")
+
     // download URL list ( List<String> )
     private val UrlModelClassUrlListField: Field by lazy {
         UrlModelClass.resolve().firstField {
@@ -334,7 +350,7 @@ object CommentEmojiHooker : YukiBaseHooker() {
 
                     injectEmojiUrls(comment, emojiUrls, prepend = true)
 
-                    YLog.debug( "$TAG: Injected ${emojiUrls.size} emoji url(s) into comment")
+                    YLog.debug("$TAG: Injected ${emojiUrls.size} emoji url(s) into comment")
                 }
                 // undo temporary edits — restore comment.imageList and actionItem.imageIndex
                 after {
@@ -429,6 +445,11 @@ object CommentEmojiHooker : YukiBaseHooker() {
                         .getExtensionFromMimeType(sourceMimeType)
                         ?: sourcePath.substringAfterLast('.', "")
                     var hasTempFile = false
+
+                    if (!sourceMimeType.startsWith("image/") && !sourceMimeType.startsWith("video/")) {
+                        YLog.error("$TAG: Source MIME type restricted, not allowed: $sourceMimeType")
+                        return@before
+                    }
 
                     // Convert video source to GIF animation
                     if (sourceMimeType.startsWith("video/")) {
@@ -530,7 +551,16 @@ object CommentEmojiHooker : YukiBaseHooker() {
                     return@after
                 }
                 val fileExt = filePath.substringAfterLast('.', "")
-                val fileMimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(fileExt) ?: return@after
+
+                val fileMimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(fileExt)
+                if (fileMimeType == null) {
+                    YLog.error("$TAG: createUri failed, unable to resolve MIME type")
+                    return@after
+                } else if (!(fileMimeType.startsWith("image/") || fileMimeType.startsWith("video/"))) {
+                    YLog.error("$TAG: createUri is not allowed for restricted MIME type. mimeType=$fileMimeType")
+                    return@after
+                }
+
                 val fileName = filePath.substring(filePath.lastIndexOf(File.separator) + 1)
                 // Ensure the virtual path has no leading '/' but strictly retains a trailing '/'.
                 val fileRelPath = filePath.substring(1, filePath.lastIndexOf(File.separator) + 1)

--- a/app/src/main/java/com/yst/mkga/hook/dy/hook/CommentEmojiHooker.kt
+++ b/app/src/main/java/com/yst/mkga/hook/dy/hook/CommentEmojiHooker.kt
@@ -1,21 +1,54 @@
 package com.yst.mkga.hook.dy.hook
 
+import com.highcapable.kavaref.KavaRef.Companion.asResolver
 import com.highcapable.kavaref.KavaRef.Companion.resolve
 import com.highcapable.yukihookapi.hook.entity.YukiBaseHooker
 import com.highcapable.yukihookapi.hook.log.YLog
 import org.luckypray.dexkit.DexKitBridge
+import java.lang.reflect.Field
 import java.lang.reflect.Modifier
 
 
 object CommentEmojiHooker : YukiBaseHooker() {
+    private val TAG = this::class.simpleName
+
+    private val CommentClass by lazyClass("com.ss.android.ugc.aweme.comment.model.Comment")
+    private val EmojiClass by lazyClass("com.ss.android.ugc.aweme.emoji.model.Emoji")
+    private val UrlModelClass by lazyClass("com.ss.android.ugc.aweme.base.model.UrlModel")
+    private val SaveImageActionItemClass by lazyClass("com.ss.android.ugc.aweme.comment.manager.longclickaction.actions.SaveImageActionItem")
+    private val CommentActionParamsClass by lazyClass("com.ss.android.ugc.aweme.comment.CommentActionParams")
+    private var saveImageActionItemClassCommentActionParamsField: Field? = null
+    private var commentActionParamsClassFragmentActivityField: Field? = null
+    private var commentActionParamsClassCommentField: Field? = null
+
+    private val CommentClassEmojiField: Field by lazy {
+        CommentClass.getDeclaredField("emoji").apply {
+            isAccessible = true
+        }
+    }
+
+    private val EmojiClassAnimateUrlField: Field by lazy {
+        EmojiClass.getDeclaredField("animateUrl")
+            .apply {
+                isAccessible = true
+            }
+    }
+
+    private val UrlModelClassUrlListField: Field by lazy {
+        UrlModelClass.getDeclaredField("urlList").apply {
+            isAccessible = true
+        }
+    }
+
     override fun onHook() {
         loadApp(name = "com.ss.android.ugc.aweme") {
             DexKitBridge.create(this.appInfo.sourceDir).use { bridge ->
+                // Force enable "Save to Album" button for emoji comments
                 bridge.findMethod {
                     matcher {
                         modifiers = Modifier.STATIC
                         params {
-                            add("com.ss.android.ugc.aweme.comment.model.Comment")
+                            add(CommentClass.name)
                             add("int")
                         }
                         returnType = "boolean"
@@ -24,7 +57,7 @@ object CommentEmojiHooker : YukiBaseHooker() {
                             add {
                                 declaredClass =
                                     "com.ss.android.ugc.aweme.comment.model.CommentImageStruct"
-                                returnType = "com.ss.android.ugc.aweme.base.model.UrlModel"
+                                returnType = UrlModelClass.name
                                 paramCount = 0
                                 addUsingField {
                                     name = "downloadUrl"
@@ -33,43 +66,127 @@ object CommentEmojiHooker : YukiBaseHooker() {
                         }
                     }
                 }.singleOrNull()?.also { result ->
-                    YLog.debug("CommentEmojiHooker: Target method found: ${result.className}.${result.methodName}")
+                    YLog.debug("$TAG: Target method found: ${result.className}.${result.methodName}")
 
                     result.className.toClass().resolve().firstMethod {
                         name = result.methodName
                     }.hook {
-                        val emojiField =
-                            result.paramTypes[0].name.toClass().getDeclaredField("emoji").apply {
-                                isAccessible = true
-                            }
-                        val animateUrlField = emojiField.type.getDeclaredField("animateUrl").apply {
-                            isAccessible = true
-                        }
-                        val urlListField = animateUrlField.type.getDeclaredField("urlList").apply {
-                            isAccessible = true
-                        }
-
                         before {
                             val comment = args[0] ?: return@before
 
-                            val emojiUrlList = runCatching {
-                                urlListField.get(animateUrlField.get(emojiField.get(comment)))
-                            }.getOrNull() as? List<*>
-
+                            val emojiUrlList = getEmojiUrlListFromCommentOrNull(comment)
                             if (emojiUrlList?.isNotEmpty() == true) {
                                 resultTrue()
                             }
                         }
                     }.result {
+                        onHookingFailure { throwable ->
+                            YLog.error("$TAG: Unable to replace with original emoji URL: ${throwable.message}")
+                        }
                         onConductFailure { param, throwable ->
-                            YLog.error("CommentEmojiHooker: Unable to replace with original emoji URL: ${throwable.message}")
+                            YLog.error("$TAG: Error during download callback hook: ${throwable.message}")
                             param.result = param.callOriginal()
+                        }
+                        onHooked {
+                            YLog.info("$TAG: Hook installed, 'Save to album' button will show for emoji comments")
                         }
                     }
                 } ?: run {
-                    YLog.warn("CommentEmojiHooker: Target method not found, comment emoji download is not active")
+                    YLog.warn("$TAG: Target method not found, save to album feature is not active")
+                }
+
+                bridge.findMethod {
+                    matcher {
+                        modifiers = Modifier.STATIC + Modifier.FINAL + Modifier.PUBLIC
+                        returnType = "java.lang.Object"
+                        params {
+                            count = 1
+                        }
+                        addUsingString("bpea-comment_save_image_to_album")
+                    }
+                }.singleOrNull()?.also { result ->
+                    YLog.debug("$TAG: Target method found: ${result.className}.${result.methodName}")
+
+                    result.className.toClass().resolve().firstMethod {
+                        name = result.methodName
+                    }.hook {
+                        before {
+                            val cbkInstance = args[0] ?: run {
+                                YLog.debug("$TAG: Failed to extract cbkInstance from args")
+                                return@before
+                            }
+
+                            val saveImageActionItem = cbkInstance.asResolver().firstField {
+                                type = "java.lang.Object"
+                            }.get() ?: run {
+                                YLog.debug("$TAG: Failed to extract saveImageActionItem from args")
+                                return@before
+                            }
+
+                            val commentActionParamsField =
+                                saveImageActionItemClassCommentActionParamsField ?: runCatching {
+                                    SaveImageActionItemClass.resolve().firstField {
+                                        type = CommentActionParamsClass.name
+                                    }.self.also {
+                                        saveImageActionItemClassCommentActionParamsField = it
+                                    }
+                                }.onFailure {
+                                    YLog.error("$TAG: Failed to find CommentActionParams field in SaveImageActionItem: ${it.message}")
+                                }.getOrNull()
+
+                            val commentActionParams =
+                                commentActionParamsField?.get(saveImageActionItem) ?: run {
+                                    YLog.debug("$TAG: Failed to get CommentActionParams from SaveImageActionItem")
+                                    return@before
+                                }
+
+                            val commentField = commentActionParamsClassCommentField ?: runCatching {
+                                CommentActionParamsClass.resolve().firstField {
+                                    type = CommentClass.name
+                                }.self.also {
+                                    commentActionParamsClassCommentField = it
+                                }
+                            }.onFailure {
+                                YLog.error("$TAG: Failed to find Comment field in CommentActionParams: ${it.message}")
+                            }.getOrNull()
+
+                            val comment = commentField?.get(commentActionParams) ?: run {
+                                YLog.debug("$TAG: Failed to get Comment from CommentActionParams")
+                                return@before
+                            }
+
+                            val emojiUrlList = getEmojiUrlListFromCommentOrNull(comment)?.takeIf {
+                                it.isNotEmpty()
+                            } ?: return@before
+
+                            YLog.warn("$TAG: Download Emoji Function is NOT IMPLEMENT yet, got ${emojiUrlList.size} emoji url(s)")
+                            return@before
+                        }
+                    }.result {
+                        onConductFailure { param, throwable ->
+                            YLog.error("$TAG: Error during download callback hook: ${throwable.message}")
+                            param.result = param.callOriginal()
+                        }
+                        onHookingFailure { throwable ->
+                            YLog.error("$TAG: Failed to install download callback hook: ${throwable.message}")
+                        }
+                        onHooked {
+                            YLog.info("$TAG: Download callback hook installed, emoji download function is active")
+                        }
+                    }
+                } ?: run {
+                    YLog.warn("$TAG: Target method not found, emoji download function is not active")
                 }
             }
         }
+    }
+
+    private fun getEmojiUrlListFromCommentOrNull(comment: Any?): List<String>? {
+        return runCatching {
+            val emoji = CommentClassEmojiField.get(comment)
+            val animateUrl = EmojiClassAnimateUrlField.get(emoji)
+            @Suppress("UNCHECKED_CAST")
+            (UrlModelClassUrlListField.get(animateUrl) as? List<String>)
+        }.getOrNull()
     }
 }

--- a/app/src/main/java/com/yst/mkga/hook/dy/hook/CommentEmojiHooker.kt
+++ b/app/src/main/java/com/yst/mkga/hook/dy/hook/CommentEmojiHooker.kt
@@ -6,6 +6,7 @@ import android.media.MediaExtractor
 import android.media.MediaFormat
 import android.media.MediaMetadataRetriever
 import android.os.Build
+import android.webkit.MimeTypeMap
 import java.io.File
 import java.lang.reflect.Field
 import java.lang.reflect.Method
@@ -711,9 +712,12 @@ object CommentEmojiHooker : YukiBaseHooker() {
                 }
 
                 val filePath = args[0] as? String
-                if (filePath.isNullOrEmpty() || !filePath.endsWith(".gif", ignoreCase = true)) {
+                if (filePath.isNullOrEmpty()) {
                     return@after
                 }
+
+                val fileExt = filePath.substringAfterLast('.', "")
+                val fileMimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(fileExt) ?: return@after
 
                 val context = UGFileUtilsClassContextField.get(null) as? Context ?: return@after
                 val fileName = filePath.substring(filePath.lastIndexOf(File.separator) + 1)
@@ -724,7 +728,7 @@ object CommentEmojiHooker : YukiBaseHooker() {
                     null,
                     context,
                     fileName,
-                    "image/gif",
+                    fileMimeType,
                     fileRelPath,
                     tokenCert
                 ) as? android.net.Uri ?: return@after

--- a/app/src/main/java/com/yst/mkga/hook/dy/hook/CommentEmojiHooker.kt
+++ b/app/src/main/java/com/yst/mkga/hook/dy/hook/CommentEmojiHooker.kt
@@ -1,13 +1,17 @@
 package com.yst.mkga.hook.dy.hook
 
+import android.content.Context
 import com.highcapable.kavaref.KavaRef.Companion.asResolver
 import com.highcapable.kavaref.KavaRef.Companion.resolve
+import com.highcapable.kavaref.condition.type.Modifiers
 import com.highcapable.yukihookapi.hook.core.YukiMemberHookCreator
 import com.highcapable.yukihookapi.hook.entity.YukiBaseHooker
 import com.highcapable.yukihookapi.hook.log.YLog
 import com.yst.mkga.hook.dy.hook.utils.HookTransaction
 import org.luckypray.dexkit.DexKitBridge
+import java.io.File
 import java.lang.reflect.Field
+import java.lang.reflect.Method
 import java.lang.reflect.Modifier
 
 object CommentEmojiHooker : YukiBaseHooker() {
@@ -20,6 +24,11 @@ object CommentEmojiHooker : YukiBaseHooker() {
     private val CommentActionParamsClass by lazyClass("com.ss.android.ugc.aweme.comment.CommentActionParams")
     private val CommentLongPressItemModelClass by lazyClass("com.ss.android.ugc.aweme.comment.ui.longpress.CommentLongPressItemModel")
     private val CommentImageStructClass by lazyClass("com.ss.android.ugc.aweme.comment.model.CommentImageStruct")
+    private val DownloadInfoClass by lazyClass("com.ss.android.socialbase.downloader.model.DownloadInfo")
+    private val UGFileUtilsKtClass by lazyClass("com.bytedance.android.ug.UGFileUtilsKt")
+    private val TokenCertClass by lazyClass("com.bytedance.bpea.cert.token.TokenCert")
+    private val DigestUtilsClass by lazyClass("com.bytedance.common.utility.DigestUtils")
+    private val CmtImageProgressDownloadListenerClass by lazyClass("com.ss.android.ugc.aweme.comment.helper.download.CmtImageProgressDownloadListener")
 
     private val CommentClassEmojiField: Field by lazy {
         CommentClass.resolve().firstField {
@@ -61,10 +70,124 @@ object CommentEmojiHooker : YukiBaseHooker() {
         }
     }
 
+    private val UGFileUtilsKtClassCopyFileMethod: Method by lazy {
+        UGFileUtilsKtClass.resolve().firstMethod {
+            name = "copyFile"
+            returnType = Boolean::class
+            modifiers(Modifiers.PUBLIC, Modifiers.STATIC, Modifiers.FINAL)
+            parameters(String::class, String::class, TokenCertClass)
+            parameterCount = 3
+        }.self.apply {
+            isAccessible = true
+        }
+    }
+
+    private val UGFileUtilsKtClassRemoveFileMethod: Method by lazy {
+        UGFileUtilsKtClass.resolve().firstMethod {
+            name = "removeFile"
+            returnType = Boolean::class
+            modifiers(Modifiers.PUBLIC, Modifiers.STATIC, Modifiers.FINAL)
+            parameters(String::class, String::class)
+            parameterCount = 2
+        }.self.apply {
+            isAccessible = true
+        }
+    }
+
+    private val UGFileUtilsKtClassGetStorageDirMethod: Method by lazy {
+        UGFileUtilsKtClass.resolve().firstMethod {
+            name = "getStorageDir"
+            returnType = String::class
+            modifiers(Modifiers.PUBLIC, Modifiers.STATIC, Modifiers.FINAL)
+            parameters(String::class, Boolean::class)
+            parameterCount = 2
+        }.self.apply {
+            isAccessible = true
+        }
+    }
+
+    private val UGFileUtilsKtClassGetExternalStorageDirectoryMethod: Method by lazy {
+        UGFileUtilsKtClass.resolve().firstMethod {
+            name = "getExternalStorageDirectory"
+            returnType = String::class
+            modifiers(Modifiers.PUBLIC, Modifiers.STATIC, Modifiers.FINAL)
+            parameters(String::class, Boolean::class)
+            parameterCount = 2
+        }.self.apply {
+            isAccessible = true
+        }
+    }
+
+    private val UGFileUtilsKtClassGetImageUriMethod: Method by lazy {
+        UGFileUtilsKtClass.resolve().firstMethod {
+            name = "getImageUri"
+            returnType = android.net.Uri::class
+            modifiers(Modifiers.PUBLIC, Modifiers.STATIC, Modifiers.FINAL)
+            parameters(android.content.Context::class, String::class, String::class, String::class, TokenCertClass)
+            parameterCount = 5
+        }.self.apply {
+            isAccessible = true
+        }
+    }
+
+    private val UGFileUtilsClassContextField: Field by lazy {
+        UGFileUtilsKtClass.resolve().firstField {
+            name = "context"
+        }.self.apply {
+            isAccessible = true
+        }
+    }
+
+    private val DigestUtilsClassMd5HexMethod: Method by lazy {
+        DigestUtilsClass.resolve().firstMethod {
+            name = "md5Hex"
+            returnType = String::class
+            modifiers(Modifiers.PUBLIC, Modifiers.STATIC)
+            parameters(String::class)
+            parameterCount = 1
+        }.self.apply {
+            isAccessible = true
+        }
+    }
+
+    private val CmtImageProgressDownloadListenerClassReportDownloadRetMethod: Method by lazy {
+        CmtImageProgressDownloadListenerClass.resolve().firstMethod {
+            modifiers(Modifiers.PUBLIC, Modifiers.FINAL)
+            parameters(Context::class, Boolean::class)
+            parameterCount = 2
+        }.self.apply {
+            isAccessible = true
+        }
+    }
+
     private var commentActionParamsClassCommentField: Field? = null
     private var commentActionParamsClassImageIndexField: Field? = null
     private var commentLongPressItemModelClassCommentActionParamsField: Field? = null
     private var saveImageActionItemClassCommentActionParamsField: Field? = null
+
+    private val downloadInfoClassUrlField: Field by lazy {
+        DownloadInfoClass.resolve().firstField {
+            name = "url"
+        }.self.apply {
+            isAccessible = true
+        }
+    }
+
+    private val downloadInfoClassSavePathField: Field by lazy {
+        DownloadInfoClass.resolve().firstField {
+            name = "savePath"
+        }.self.apply {
+            isAccessible = true
+        }
+    }
+
+    private val downloadInfoClassGetTargetFilePathMethod: Method by lazy {
+        DownloadInfoClass.resolve().firstMethod {
+            name = "getTargetFilePath"
+        }.self.apply {
+            isAccessible = true
+        }
+    }
 
     override fun onHook() {
         withProcess(mainProcessName) {
@@ -76,19 +199,26 @@ object CommentEmojiHooker : YukiBaseHooker() {
                 transaction.add(::installClickSaveEmojiToAlbumButtonCallbackHook.name) {
                     installClickSaveEmojiToAlbumButtonCallbackHook(bridge)
                 }
+                transaction.add(::installCreateGifUrihook.name) {
+                    installCreateGifUrihook(bridge)
+                }
+                transaction.add(::installEmojiDownloadedCallbackHook.name) {
+                    installEmojiDownloadedCallbackHook(bridge)
+                }
                 transaction.commit()
             }
         }
     }
 
     private fun extractActionParams(actionItem: Any): Any? {
-        val field = commentLongPressItemModelClassCommentActionParamsField ?: CommentLongPressItemModelClass.resolve()
-            .firstField {
-                type = CommentActionParamsClass.name
-            }.self.also {
-                it.isAccessible = true
-                commentLongPressItemModelClassCommentActionParamsField = it
-            }
+        val field = commentLongPressItemModelClassCommentActionParamsField
+            ?: CommentLongPressItemModelClass.resolve()
+                .firstField {
+                    type = CommentActionParamsClass.name
+                }.self.also {
+                    it.isAccessible = true
+                    commentLongPressItemModelClassCommentActionParamsField = it
+                }
         return field.get(actionItem)
     }
 
@@ -102,6 +232,13 @@ object CommentEmojiHooker : YukiBaseHooker() {
                 commentActionParamsClassCommentField = it
             }
         return field.get(params)
+    }
+
+    private fun convertHeif2Gif(heifPath: String, gifPath: String): Boolean {
+        return runCatching {
+            File(heifPath).copyTo(File(gifPath), overwrite = true)
+            true
+        }.getOrDefault(false)
     }
 
     private fun extractEmojiUrls(comment: Any): List<String>? {
@@ -288,6 +425,186 @@ object CommentEmojiHooker : YukiBaseHooker() {
             }
         } ?: run {
             YLog.warn("$TAG: Target method not found, download callback hook will not be installed")
+        }
+
+        return ret
+    }
+
+    private fun installEmojiDownloadedCallbackHook(bridge: DexKitBridge): YukiMemberHookCreator.MemberHookCreator.Result? {
+        var ret: YukiMemberHookCreator.MemberHookCreator.Result? = null
+
+        bridge.findMethod {
+            matcher {
+                name = "onSuccessed"
+                modifiers = Modifier.FINAL + Modifier.PUBLIC
+                returnType = "void"
+                params {
+                    add("com.ss.android.socialbase.downloader.model.DownloadInfo")
+                }
+                usingStrings {
+                    add("/douyin/comment")
+                    add("comment_")
+                }
+                invokeMethods {
+                    add {
+                        descriptor =
+                            "Lcom/bytedance/android/ug/UGFileUtilsKt;->copyFile(Ljava/lang/String;Ljava/lang/String;Lcom/bytedance/bpea/cert/token/TokenCert;)Z"
+                    }
+                }
+            }
+        }.singleOrNull()?.also { match ->
+            YLog.debug("$TAG: Target method found: ${match.className}.${match.methodName}")
+
+            match.className.toClass().resolve().firstMethod {
+                name = match.methodName
+            }.hook {
+                before {
+                    val downloadInfo = args[0] ?: return@before
+
+                    val dlUrl =
+                        downloadInfoClassUrlField.get(downloadInfo) as? String ?: return@before
+
+                    if (!dlUrl.contains(".heif")) {
+                        return@before
+                    }
+
+                    //val sourcePath =
+                    //downloadInfoClassSavePathField.get(downloadInfo) as? String ?: return@before
+                    val sourcePath =
+                        downloadInfoClassGetTargetFilePathMethod.invoke(downloadInfo) as? String
+                            ?: return@before
+                    YLog.debug("$TAG: Source path: $sourcePath")
+
+                    val gifFileName = "comment_${
+                        DigestUtilsClassMd5HexMethod.invoke(
+                            null,
+                            dlUrl + System.currentTimeMillis().toString()
+                        ) as String?
+                    }.gif"
+                    val gifTempPath = "${
+                        UGFileUtilsKtClassGetStorageDirMethod.invoke(
+                            null,
+                            "/comment/images",
+                            false
+                        ) as String
+                    }${File.separator}${gifFileName}"
+                    YLog.debug("$TAG: GIF temp path: $gifTempPath")
+                    if (!convertHeif2Gif(sourcePath, gifTempPath)) {
+                        YLog.error("$TAG: Convert HEIF To GIF failed")
+                        return@before
+                    }
+
+                    val gifSavePath = "${
+                        UGFileUtilsKtClassGetExternalStorageDirectoryMethod.invoke(
+                            null,
+                            "/douyin/comment",
+                            false
+                        ) as String
+                    }${File.separator}${gifFileName}"
+                    YLog.debug("$TAG: GIF save path: $gifSavePath")
+
+                    val cpRet = UGFileUtilsKtClassCopyFileMethod.invoke(
+                        null,
+                        gifTempPath,
+                        gifSavePath,
+                        TokenCertClass.getConstructor(String::class.java)
+                            .newInstance("bpea-comment_save_image_to_album")
+                    ) as Boolean
+
+                    File(gifTempPath).delete()
+
+                    val context =
+                        instance.asResolver().firstField().get()?.asResolver()?.firstField {
+                            type = Context::class
+                        }?.get<Context?>()
+
+                    YLog.debug("$TAG: cpRet: $cpRet")
+                    CmtImageProgressDownloadListenerClassReportDownloadRetMethod.invoke(
+                        instance,
+                        context,
+                        cpRet
+                    )
+
+                    resultNull()
+                }
+            }.result {
+                onConductFailure { param, throwable ->
+                    YLog.error("$TAG: Emoji download completion callback runtime error", throwable)
+                }
+                onHookingFailure { throwable ->
+                    YLog.error("$TAG: Failed to hook emoji download completion callback", throwable)
+                }
+                onHooked {
+                    YLog.info("$TAG: Emoji download completion callback hooked. Emoji will be converted to GIF before saving to album.")
+                }.also {
+                    ret = it
+                }
+            }
+        } ?: run {
+            YLog.warn("$TAG: Target method not found, emoji save completion callback will not be installed")
+        }
+
+        return ret
+    }
+
+    @Suppress("UNUSED_PARAMETER")
+    private fun installCreateGifUrihook(unused: DexKitBridge): YukiMemberHookCreator.MemberHookCreator.Result? {
+        var ret: YukiMemberHookCreator.MemberHookCreator.Result? = null
+
+        UGFileUtilsKtClass.resolve().firstMethod {
+            name = "createUri"
+            returnType = android.net.Uri::class
+            modifiers(Modifiers.PUBLIC, Modifiers.STATIC, Modifiers.FINAL)
+            parameters(String::class, Boolean::class, Array<android.net.Uri>::class, TokenCertClass)
+            parameterCount = 4
+        }.hook {
+            after {
+                val uriRet = result as? android.net.Uri
+                if (uriRet != null && uriRet != android.net.Uri.EMPTY) {
+                    return@after
+                }
+
+                val filePath = args[0] as? String
+                if (filePath.isNullOrEmpty() || !filePath.endsWith(".gif", ignoreCase = true)) {
+                    return@after
+                }
+
+                val context = UGFileUtilsClassContextField.get(null) as? Context ?: return@after
+                val fileName = filePath.substring(filePath.lastIndexOf(File.separator) + 1)
+                val fileRelPath = filePath.substring(1, filePath.lastIndexOf(File.separator) + 1)
+                val tokenCert = args[3]
+
+                val finalUri = UGFileUtilsKtClassGetImageUriMethod.invoke(
+                    null,
+                    context,
+                    fileName,
+                    "image/gif",
+                    fileRelPath,
+                    tokenCert
+                ) as? android.net.Uri ?: return@after
+                result = finalUri
+                YLog.debug("$TAG: finalUri: $finalUri")
+
+
+                @Suppress("UNCHECKED_CAST")
+                val uriArr = args[2] as? Array<android.net.Uri> ?: return@after
+
+                if (uriArr.isNotEmpty()) {
+                    uriArr[0] = finalUri
+                }
+            }
+        }.result {
+            onConductFailure { param, throwable ->
+                YLog.error("$TAG: createUri hook runtime error", throwable)
+            }
+            onHookingFailure { throwable ->
+                YLog.error("$TAG: Failed to hook createUri", throwable)
+            }
+            onHooked {
+                YLog.info("$TAG: createUri hooked. URI creation will be intercepted for emoji GIF conversion.")
+            }.also {
+                ret = it
+            }
         }
 
         return ret

--- a/app/src/main/java/com/yst/mkga/hook/dy/hook/CommentEmojiHooker.kt
+++ b/app/src/main/java/com/yst/mkga/hook/dy/hook/CommentEmojiHooker.kt
@@ -1,6 +1,5 @@
 package com.yst.mkga.hook.dy.hook
 
-import com.highcapable.kavaref.KavaRef.Companion.asResolver
 import com.highcapable.kavaref.KavaRef.Companion.resolve
 import com.highcapable.yukihookapi.hook.entity.YukiBaseHooker
 import com.highcapable.yukihookapi.hook.log.YLog
@@ -39,15 +38,23 @@ object CommentEmojiHooker : YukiBaseHooker() {
                     result.className.toClass().resolve().firstMethod {
                         name = result.methodName
                     }.hook {
+                        val emojiField =
+                            result.paramTypes[0].name.toClass().getDeclaredField("emoji").apply {
+                                isAccessible = true
+                            }
+                        val animateUrlField = emojiField.type.getDeclaredField("animateUrl").apply {
+                            isAccessible = true
+                        }
+                        val urlListField = animateUrlField.type.getDeclaredField("urlList").apply {
+                            isAccessible = true
+                        }
+
                         before {
-                            val comment = args[0]
-                            val emojiUrlList = comment?.asResolver()?.firstField {
-                                name = "emoji"
-                            }?.get()?.asResolver()?.firstField {
-                                name = "animateUrl"
-                            }?.get()?.asResolver()?.firstField {
-                                name = "urlList"
-                            }?.get<List<String>>()
+                            val comment = args[0] ?: return@before
+
+                            val emojiUrlList = runCatching {
+                                urlListField.get(animateUrlField.get(emojiField.get(comment)))
+                            }.getOrNull() as? List<*>
 
                             if (emojiUrlList?.isNotEmpty() == true) {
                                 resultTrue()

--- a/app/src/main/java/com/yst/mkga/hook/dy/hook/CommentEmojiHooker.kt
+++ b/app/src/main/java/com/yst/mkga/hook/dy/hook/CommentEmojiHooker.kt
@@ -27,6 +27,7 @@ import com.shakster.gifkt.GifEncoder
 import org.luckypray.dexkit.DexKitBridge
 
 import com.yst.mkga.hook.dy.hook.utils.HookTransaction
+import com.yst.mkga.hook.dy.hook.utils.FileTypeDetector
 
 object CommentEmojiHooker : YukiBaseHooker() {
     private val TAG = this::class.simpleName
@@ -614,51 +615,76 @@ object CommentEmojiHooker : YukiBaseHooker() {
                         return@before
                     }
 
-                    //val sourcePath =
-                    //downloadInfoClassSavePathField.get(downloadInfo) as? String ?: return@before
                     val sourcePath =
                         downloadInfoClassGetTargetFilePathMethod.invoke(downloadInfo) as? String
                             ?: return@before
                     YLog.debug("$TAG: Source path: $sourcePath")
 
-                    val gifFileName = "comment_${
+                    val saveFileMimeType = FileTypeDetector.detect(sourcePath).mimeType
+                    YLog.debug("$TAG: Save file mime type: $saveFileMimeType")
+
+                    val saveFilePrefix = "comment_${
                         DigestUtilsClassMd5HexMethod.invoke(
                             null,
                             dlUrl + System.currentTimeMillis().toString()
                         ) as String?
-                    }.gif"
-                    val gifTempPath = "${
-                        UGFileUtilsKtClassGetStorageDirMethod.invoke(
-                            null,
-                            "/comment/images",
-                            false
-                        ) as String
-                    }${File.separator}${gifFileName}"
-                    YLog.debug("$TAG: GIF temp path: $gifTempPath")
+                    }"
 
-                    if (!convertMedia2Gif(sourcePath, gifTempPath)) {
-                        YLog.error("$TAG: Convert HEIF To GIF failed")
-                        return@before
+                    var cpRet: Boolean? = null
+                    if (saveFileMimeType.startsWith("video/")) {
+                        val saveFileName = "${saveFilePrefix}.gif"
+                        val saveFilePath = "${
+                            UGFileUtilsKtClassGetExternalStorageDirectoryMethod.invoke(
+                                null,
+                                "/douyin/comment",
+                                false
+                            ) as String
+                        }${File.separator}${saveFileName}"
+                        YLog.debug("$TAG: GIF save path: $saveFilePath")
+
+                        val gifTempPath = "${
+                            UGFileUtilsKtClassGetStorageDirMethod.invoke(
+                                null,
+                                "/comment/images",
+                                false
+                            ) as String
+                        }${File.separator}${saveFileName}"
+                        YLog.debug("$TAG: GIF temp path: $gifTempPath")
+
+                        if (!convertMedia2Gif(sourcePath, gifTempPath)) {
+                            YLog.error("$TAG: Convert HEIF To GIF failed")
+                            return@before
+                        }
+
+                        cpRet = UGFileUtilsKtClassCopyFileMethod.invoke(
+                            null,
+                            gifTempPath,
+                            saveFilePath,
+                            TokenCertClass.getConstructor(String::class.java)
+                                .newInstance("bpea-comment_save_image_to_album")
+                        ) as Boolean
+
+                        File(gifTempPath).delete()
+                    } else {
+                        val saveFileExt = MimeTypeMap.getSingleton().getExtensionFromMimeType(saveFileMimeType)
+                            ?: sourcePath.substringAfterLast('.', "")
+                        val saveFileName = "${saveFilePrefix}.${saveFileExt}"
+                        val saveFilePath = "${
+                            UGFileUtilsKtClassGetExternalStorageDirectoryMethod.invoke(
+                                null,
+                                "/douyin/comment",
+                                false
+                            ) as String
+                        }${File.separator}${saveFileName}"
+
+                        cpRet = UGFileUtilsKtClassCopyFileMethod.invoke(
+                            null,
+                            sourcePath,
+                            saveFilePath,
+                            TokenCertClass.getConstructor(String::class.java)
+                                .newInstance("bpea-comment_save_image_to_album")
+                        ) as Boolean
                     }
-
-                    val gifSavePath = "${
-                        UGFileUtilsKtClassGetExternalStorageDirectoryMethod.invoke(
-                            null,
-                            "/douyin/comment",
-                            false
-                        ) as String
-                    }${File.separator}${gifFileName}"
-                    YLog.debug("$TAG: GIF save path: $gifSavePath")
-
-                    val cpRet = UGFileUtilsKtClassCopyFileMethod.invoke(
-                        null,
-                        gifTempPath,
-                        gifSavePath,
-                        TokenCertClass.getConstructor(String::class.java)
-                            .newInstance("bpea-comment_save_image_to_album")
-                    ) as Boolean
-
-                    File(gifTempPath).delete()
 
                     val context =
                         instance.asResolver().firstField().get()?.asResolver()?.firstField {

--- a/app/src/main/java/com/yst/mkga/hook/dy/hook/HookEntry.kt
+++ b/app/src/main/java/com/yst/mkga/hook/dy/hook/HookEntry.kt
@@ -23,5 +23,6 @@ object HookEntry : IYukiHookXposedInit {
         }
 
         loadApp(hooker = CommentImageHooker)
+        loadApp(hooker = CommentEmojiHooker)
     }
 }

--- a/app/src/main/java/com/yst/mkga/hook/dy/hook/utils/FileTypeDetector.kt
+++ b/app/src/main/java/com/yst/mkga/hook/dy/hook/utils/FileTypeDetector.kt
@@ -1,0 +1,330 @@
+package com.yst.mkga.hook.dy.hook.utils
+
+import java.io.File
+
+object FileTypeDetector {
+    data class FileTypeInfo(
+        val mimeType: String,
+        val extensions: List<String>,
+        val description: String
+    )
+
+    object MimeTypes {
+        // Images
+        val JPEG = FileTypeInfo("image/jpeg", listOf("jpg", "jpeg"), "JPEG Image")
+        val PNG = FileTypeInfo("image/png", listOf("png"), "PNG Image")
+        val GIF = FileTypeInfo("image/gif", listOf("gif"), "GIF Image")
+        val BMP = FileTypeInfo("image/bmp", listOf("bmp"), "BMP Image")
+        val TIFF_LE = FileTypeInfo("image/tiff", listOf("tif", "tiff"), "TIFF Image (LE)")
+        val TIFF_BE = FileTypeInfo("image/tiff", listOf("tif", "tiff"), "TIFF Image (BE)")
+        val ICO = FileTypeInfo("image/x-icon", listOf("ico"), "Icon Image")
+        val PSD = FileTypeInfo("image/vnd.adobe.photoshop", listOf("psd"), "Photoshop Document")
+        val WEBP = FileTypeInfo("image/webp", listOf("webp"), "WebP Image")
+        val HEIC = FileTypeInfo("image/heic", listOf("heic", "heif"), "HEIF Image")
+        val HEIF = FileTypeInfo("image/heif", listOf("heif"), "HEIF Image (MIF1)")
+        val AVIF = FileTypeInfo("image/avif", listOf("avif"), "AVIF Image")
+        val ANI = FileTypeInfo("image/x-ani", listOf("ani"), "Animated Cursor")
+
+        // Audio
+        val MP3_ID3 = FileTypeInfo("audio/mpeg", listOf("mp3", "mpga"), "MPEG Audio (ID3)")
+        val MP3_RAW = FileTypeInfo("audio/mpeg", listOf("mp3", "mp2"), "MPEG Audio (Raw Frame)")
+        val FLAC = FileTypeInfo("audio/flac", listOf("flac"), "FLAC Audio")
+        val OGG = FileTypeInfo("audio/ogg", listOf("ogg", "oga", "opus"), "Ogg Audio")
+        val AMR = FileTypeInfo("audio/amr", listOf("amr"), "AMR Audio")
+        val MIDI = FileTypeInfo("audio/midi", listOf("mid", "midi"), "MIDI Audio")
+        val WAV = FileTypeInfo("audio/wav", listOf("wav", "wave"), "WAV Audio")
+        val M4A = FileTypeInfo("audio/mp4", listOf("m4a", "m4b"), "MPEG-4 Audio")
+
+        // Video
+        val MP4 = FileTypeInfo("video/mp4", listOf("mp4", "m4v", "f4v"), "MPEG-4 Video")
+        val QUICKTIME = FileTypeInfo("video/quicktime", listOf("mov", "qt"), "QuickTime Video")
+        val V_3GPP = FileTypeInfo("video/3gpp", listOf("3gp", "3gpp"), "3GPP Video")
+        val V_3GPP2 = FileTypeInfo("video/3gpp2", listOf("3g2", "3gpp2"), "3GPP2 Video")
+        val AVI = FileTypeInfo("video/avi", listOf("avi"), "AVI Video")
+        val FLV = FileTypeInfo("video/x-flv", listOf("flv"), "Flash Video")
+        val MPEG_PS = FileTypeInfo("video/mpeg", listOf("mpg", "mpeg"), "MPEG-PS Video")
+        val MATROSKA = FileTypeInfo("video/x-matroska", listOf("mkv", "webm"), "Matroska/WebM Media")
+        val REALMEDIA = FileTypeInfo("application/vnd.rn-realmedia", listOf("rm", "rmvb"), "RealMedia Video")
+
+        // Documents & Archives
+        val PDF = FileTypeInfo("application/pdf", listOf("pdf"), "PDF Document")
+        val RTF = FileTypeInfo("application/rtf", listOf("rtf"), "Rich Text Format")
+        val ZIP = FileTypeInfo("application/zip", listOf("zip", "apk", "docx", "xlsx", "jar"), "Zip Archive")
+        val ZIP_EMPTY = FileTypeInfo("application/zip", listOf("zip"), "Zip Archive (Empty)")
+        val RAR = FileTypeInfo("application/vnd.rar", listOf("rar"), "RAR Archive")
+        val RAR5 = FileTypeInfo("application/vnd.rar", listOf("rar"), "RAR5 Archive")
+        val SEVEN_Z = FileTypeInfo("application/x-7z-compressed", listOf("7z"), "7-Zip Archive")
+        val GZIP = FileTypeInfo("application/gzip", listOf("gz", "gzip"), "Gzip Archive")
+        val BZIP2 = FileTypeInfo("application/x-bzip2", listOf("bz2"), "Bzip2 Archive")
+
+        // Fonts & Executables & Others
+        val TTF = FileTypeInfo("font/ttf", listOf("ttf"), "TrueType Font")
+        val OTF = FileTypeInfo("font/otf", listOf("otf"), "OpenType Font")
+        val WOFF = FileTypeInfo("font/woff", listOf("woff"), "Web Open Font Format")
+        val WOFF2 = FileTypeInfo("font/woff2", listOf("woff2"), "Web Open Font Format 2")
+        val SWF = FileTypeInfo("application/x-shockwave-flash", listOf("swf"), "Flash SWF")
+        val WASM = FileTypeInfo("application/wasm", listOf("wasm"), "WebAssembly Binary")
+        val JAVA_CLASS = FileTypeInfo("application/java-vm", listOf("class"), "Java Class File")
+        val SQLITE = FileTypeInfo("application/x-sqlite3", listOf("db", "sqlite"), "SQLite Database")
+        val OLE2 = FileTypeInfo("application/x-ole-storage", listOf("doc", "xls", "ppt"), "OLE2 Compound Document")
+        val DEX = FileTypeInfo("application/vnd.android.dex", listOf("dex"), "Android DEX")
+        val ODEX = FileTypeInfo("application/vnd.android.odex", listOf("odex"), "Android ODEX")
+
+        // Fallback
+        val OCTET_STREAM = FileTypeInfo("application/octet-stream", listOf("bin"), "Binary Data")
+    }
+
+    interface DetectionRule {
+        fun match(bytes: ByteArray): FileTypeInfo?
+    }
+
+    class ExactMatchRule(
+        private val offset: Int,
+        private val magic: ByteArray,
+        val info: FileTypeInfo
+    ) : DetectionRule {
+        override fun match(bytes: ByteArray): FileTypeInfo? {
+            if (bytes.size < offset + magic.size) {
+                return null
+            }
+            for (i in magic.indices) {
+                if (bytes[offset + i] != magic[i]) {
+                    return null
+                }
+            }
+            return info
+        }
+    }
+
+    data class MaskedMatchRule(
+        val offset: Int,
+        val magic: ByteArray,
+        val mask: ByteArray,
+        val info: FileTypeInfo
+    ) : DetectionRule {
+        override fun match(bytes: ByteArray): FileTypeInfo? {
+            if (bytes.size < offset + magic.size) {
+                return null
+            }
+            for (i in magic.indices) {
+                if ((bytes[offset + i].toInt() and mask[i].toInt()) != (magic[i].toInt() and mask[i].toInt())) {
+                    return null
+                }
+            }
+            return info
+        }
+    }
+
+    class FtypContainerRule : DetectionRule {
+        override fun match(bytes: ByteArray): FileTypeInfo? {
+            if (bytes.size < 12) {
+                return null
+            }
+            if (String(bytes, 4, 4, Charsets.US_ASCII) != "ftyp") {
+                return null
+            }
+
+            return when (val brand = String(bytes, 8, 4, Charsets.US_ASCII)) {
+                "heic", "hevc", "hevx", "heim", "heis" -> MimeTypes.HEIC
+                "mif1" -> MimeTypes.HEIF
+                "avif", "avis" -> MimeTypes.AVIF
+                "M4A ", "M4B ", "mp4a" -> MimeTypes.M4A
+                "qt  " -> MimeTypes.QUICKTIME
+                else -> {
+                    if (brand.startsWith("3gp") || brand.startsWith("3gr") || brand.startsWith("3gs")) {
+                        MimeTypes.V_3GPP
+                    } else if (brand.startsWith("3g2")) {
+                        MimeTypes.V_3GPP2
+                    } else {
+                        MimeTypes.MP4
+                    }
+                }
+            }
+        }
+    }
+
+    class RiffContainerRule : DetectionRule {
+        override fun match(bytes: ByteArray): FileTypeInfo? {
+            if (bytes.size < 12) {
+                return null
+            }
+            if (String(bytes, 0, 4, Charsets.US_ASCII) != "RIFF") {
+                return null
+            }
+
+            val subType = String(bytes, 8, 4, Charsets.US_ASCII)
+            return when (subType) {
+                "WAVE" -> MimeTypes.WAV
+                "WEBP" -> MimeTypes.WEBP
+                "AVI " -> MimeTypes.AVI
+                "ACON" -> MimeTypes.ANI
+                else -> null
+            }
+        }
+    }
+
+    private val DEFAULT_RULES: List<DetectionRule> = buildList {
+        add(FtypContainerRule())
+        add(RiffContainerRule())
+
+        // --- Images ---
+        add(
+            ExactMatchRule(
+                0,
+                byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte()),
+                FileTypeInfo("image/jpeg", listOf("jpg", "jpeg"), "JPEG Image")
+            )
+        )
+        add(
+            ExactMatchRule(
+                0,
+                byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A),
+                FileTypeInfo("image/png", listOf("png"), "PNG Image")
+            )
+        )
+        add(
+            ExactMatchRule(
+                0,
+                "GIF8".toByteArray(Charsets.US_ASCII),
+                FileTypeInfo("image/gif", listOf("gif"), "GIF Image")
+            )
+        )
+        add(
+            ExactMatchRule(
+                0,
+                "BM".toByteArray(Charsets.US_ASCII),
+                FileTypeInfo("image/bmp", listOf("bmp"), "BMP Image")
+            )
+        )
+
+        // --- Audio ---
+        add(
+            ExactMatchRule(
+                0,
+                "ID3".toByteArray(Charsets.US_ASCII),
+                FileTypeInfo("audio/mpeg", listOf("mp3", "mpga"), "MPEG Audio (ID3)")
+            )
+        )
+        add(
+            ExactMatchRule(
+                0,
+                "fLaC".toByteArray(Charsets.US_ASCII),
+                FileTypeInfo("audio/flac", listOf("flac"), "FLAC Audio")
+            )
+        )
+        add(
+            ExactMatchRule(
+                0,
+                "OggS".toByteArray(Charsets.US_ASCII),
+                FileTypeInfo("audio/ogg", listOf("ogg", "oga"), "Ogg Audio")
+            )
+        )
+        add(
+            MaskedMatchRule(
+                0,
+                byteArrayOf(0xFF.toByte(), 0xE0.toByte()),
+                byteArrayOf(0xFF.toByte(), 0xE0.toByte()),
+                FileTypeInfo("audio/mpeg", listOf("mp3"), "MPEG Audio (Raw Frame)")
+            )
+        )
+
+        // --- Video ---
+        add(
+            ExactMatchRule(
+                0,
+                "FLV".toByteArray(Charsets.US_ASCII),
+                FileTypeInfo("video/x-flv", listOf("flv"), "Flash Video")
+            )
+        )
+        add(
+            ExactMatchRule(
+                0,
+                byteArrayOf(0x1A.toByte(), 0x45.toByte(), 0xDF.toByte(), 0xA3.toByte()),
+                FileTypeInfo("video/x-matroska", listOf("mkv", "webm"), "Matroska/WebM")
+            )
+        )
+
+        // --- Documents & Archives ---
+        add(
+            ExactMatchRule(
+                0,
+                "%PDF".toByteArray(Charsets.US_ASCII),
+                FileTypeInfo("application/pdf", listOf("pdf"), "PDF Document")
+            )
+        )
+        add(
+            ExactMatchRule(
+                0,
+                byteArrayOf(0x50, 0x4B, 0x03, 0x04),
+                FileTypeInfo("application/zip", listOf("zip", "apk", "docx", "xlsx"), "Zip Archive")
+            )
+        )
+        add(
+            ExactMatchRule(
+                0,
+                "Rar!\u001A\u0007\u0000".toByteArray(Charsets.US_ASCII),
+                FileTypeInfo("application/vnd.rar", listOf("rar"), "RAR Archive")
+            )
+        )
+        add(
+            ExactMatchRule(
+                0,
+                byteArrayOf(0x37, 0x7A, 0xBC.toByte(), 0xAF.toByte(), 0x27, 0x1C),
+                FileTypeInfo("application/x-7z-compressed", listOf("7z"), "7-Zip Archive")
+            )
+        )
+
+        // --- Android Specific ---
+        add(
+            ExactMatchRule(
+                0,
+                "dex\n".toByteArray(Charsets.US_ASCII),
+                FileTypeInfo("application/vnd.android.dex", listOf("dex"), "Android DEX")
+            )
+        )
+        add(
+            ExactMatchRule(
+                0,
+                "dey\n".toByteArray(Charsets.US_ASCII),
+                FileTypeInfo("application/vnd.android.odex", listOf("odex"), "Android ODEX")
+            )
+        )
+    }
+
+    fun detect(bytes: ByteArray): FileTypeInfo {
+        if (bytes.isEmpty()) {
+            return MimeTypes.OCTET_STREAM
+        }
+        for (matcher in DEFAULT_RULES) {
+            val result = matcher.match(bytes)
+            if (result != null) {
+                return result
+            }
+        }
+        return MimeTypes.OCTET_STREAM
+    }
+
+    fun detect(file: File, headerSize: Int = 32): FileTypeInfo {
+        if (!file.exists() || !file.isFile || file.length() == 0L) {
+            return MimeTypes.OCTET_STREAM
+        }
+        return file.inputStream().use { fis ->
+            val buffer = ByteArray(headerSize)
+            val bytesRead = fis.read(buffer)
+            if (bytesRead > 0) {
+                detect(
+                    if (bytesRead < buffer.size) {
+                        buffer.copyOf(bytesRead)
+                    } else {
+                        buffer
+                    }
+                )
+            } else {
+                MimeTypes.OCTET_STREAM
+            }
+        }
+    }
+
+
+    fun detect(filePath: String, headerSize: Int = 32): FileTypeInfo = detect(File(filePath))
+}

--- a/app/src/main/java/com/yst/mkga/hook/dy/hook/utils/HookTransaction.kt
+++ b/app/src/main/java/com/yst/mkga/hook/dy/hook/utils/HookTransaction.kt
@@ -1,0 +1,60 @@
+package com.yst.mkga.hook.dy.hook.utils
+
+import com.highcapable.yukihookapi.hook.core.YukiMemberHookCreator.MemberHookCreator
+import com.highcapable.yukihookapi.hook.log.YLog
+
+class HookTransaction(private val tag: String?) {
+    private val hookActions = mutableListOf<Pair<String, () -> MemberHookCreator.Result?>>()
+    private val hookResult = mutableListOf<MemberHookCreator.Result>()
+
+    private fun rollback() {
+        hookResult.asReversed().forEachIndexed { index, result ->
+            runCatching {
+                result.remove()
+            }.onFailure { e ->
+                YLog.error(
+                    "$tag: Hook at index $index rollback failed, ignore it. Stack trace: ",
+                    e
+                )
+            }
+        }
+        hookResult.clear()
+    }
+
+    fun reset() {
+        hookActions.clear()
+        hookResult.clear()
+    }
+
+    fun add(name: String, action: () -> MemberHookCreator.Result?) {
+        hookActions.add(Pair(name, action))
+    }
+
+    fun commit() {
+        var hasFailure = false
+        for ((name, action) in hookActions) {
+            if (hasFailure) {
+                break
+            }
+
+            try {
+                action()?.also {
+                    hookResult.add(it)
+                } ?: run {
+                    hasFailure = true
+                    YLog.error("$tag: $name returned null, considered as hook failed. The remaining hooks will not be executed and rollback will be performed.")
+                }
+            } catch (e: Exception) {
+                hasFailure = true
+                YLog.error(
+                    "$tag: $name threw an exception! The remaining hooks will not be executed and rollback will be performed. Stack trace: ",
+                    e
+                )
+            }
+        }
+
+        if (hasFailure) {
+            rollback()
+        }
+    }
+}

--- a/app/src/main/java/com/yst/mkga/hook/dy/hook/utils/HookTransaction.kt
+++ b/app/src/main/java/com/yst/mkga/hook/dy/hook/utils/HookTransaction.kt
@@ -30,7 +30,7 @@ class HookTransaction(private val tag: String?) {
         hookActions.add(Pair(name, action))
     }
 
-    fun commit() {
+    fun commit(): Boolean {
         var hasFailure = false
         for ((name, action) in hookActions) {
             if (hasFailure) {
@@ -56,5 +56,7 @@ class HookTransaction(private val tag: String?) {
         if (hasFailure) {
             rollback()
         }
+
+        return !hasFailure
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ ksp = "2.3.9"
 kavaref-core = "1.0.3"
 kavaref-extension = "1.0.3"
 dexkit = "2.2.0"
+gifkt = "0.3.3"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -29,6 +30,7 @@ kavaref-extension = { module = "com.highcapable.kavaref:kavaref-extension", vers
 # 作为 Xposed 模块使用务必添加，其它情况可选
 xposed-api = { module = "de.robv.android.xposed:api", version = "82" }
 luckypray-dexkit = { group = "org.luckypray", name = "dexkit", version.ref = "dexkit" }
+gifkt = { module = "com.shakster:gifkt", version.ref = "gifkt" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
- Force "save to album" button visible for emoji comments.
- Inject emoji URLs into the download pipeline so the downloader can pick them up.
- Convert video-based emojis to GIF animation for album compatibility.
- All four hooks are installed atomically with automatic rollback on failure.

Introduced [gifkt](https://github.com/shaksternano/gif.kt) for GIF encoding.