### PR TITLE
Guard against empty method or field names and catch obfuscated lookup failures

### DIFF
--- a/.github/workflows/spotless_check.yml
+++ b/.github/workflows/spotless_check.yml
@@ -1,0 +1,32 @@
+name: Spotless Format Check
+
+on:
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - 'app/src/**'
+      - '**.gradle'
+      - '**.gradle.kts'
+      - 'gradle.properties'
+
+permissions:
+    contents: read
+
+jobs:
+  spotless:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - name: Setup Java JDK
+        uses: actions/setup-java@v5.2.0
+        with:
+          java-version: "21"
+          distribution: "temurin"
+
+      - name: Run Spotless Check
+        run: bash ./gradlew spotlessCheck


### PR DESCRIPTION
- Reject null, empty, and blank names in reflect helpers before attempting resolution
- Isolate each obfuscated method lookup so a single failure does not block subsequent lookups, preventing unrelated features from breaking
