### PR TITLE
Restructure hook info proto, switch to applicationId, and drop DexKitBridge from CommentEmojiHooker

### DIFF
--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/CommentEmojiHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/CommentEmojiHooker.kt
@@ -69,7 +69,7 @@ object CommentEmojiHooker : YukiBaseHooker() {
         packageInstance.commentExtensionsKt.selfClass
             ?.resolve()
             ?.firstMethod {
-                name = packageInstance.commentExtensionsKt.saveToAlbumVisibility().name
+                name = packageInstance.commentExtensionsKt.hasValidImageUrl().name
             }?.hook {
                 before {
                     val comment = args[0] ?: return@before
@@ -106,10 +106,10 @@ object CommentEmojiHooker : YukiBaseHooker() {
 
         val packageInstance = DouyinPackage.instance
 
-        packageInstance.commentSaveToAlbumButtonClick.selfClass
+        packageInstance.saveImageActionItem.onClickExecutor.selfClass
             ?.resolve()
             ?.firstMethodOrNull {
-                name = packageInstance.commentSaveToAlbumButtonClick.onClicked().name
+                name = packageInstance.saveImageActionItem.onClickExecutor.onClick().name
             }?.hook {
                 var savedComment: Any? = null
                 var savedActionItem: Any? = null

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/CommentEmojiHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/CommentEmojiHooker.kt
@@ -27,7 +27,6 @@ import kotlinx.io.Sink
 import kotlinx.io.buffered
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
-import org.luckypray.dexkit.DexKitBridge
 
 object CommentEmojiHooker : YukiBaseHooker() {
     private val TAG = this::class.simpleName
@@ -35,36 +34,34 @@ object CommentEmojiHooker : YukiBaseHooker() {
     override fun onHook() {
         withProcess(mainProcessName) {
             val transaction = HookTransaction(TAG)
-            DexKitBridge.create(this.appInfo.sourceDir).use { bridge ->
-                // Force "save to album" button visible for emoji comments.
-                transaction.add(::installSaveEmojiToAlbumButtonHook.name) {
-                    installSaveEmojiToAlbumButtonHook(bridge)
-                }
-                // Before the save button's download callback fires, inject emoji URLs into
-                // comment.imageList[0].downloadUrl so the downloader picks them up.
-                // Without it: the downloader fetches nothing because imageList is empty.
-                transaction.add(::installClickSaveEmojiToAlbumButtonCallbackHook.name) {
-                    installClickSaveEmojiToAlbumButtonCallbackHook(bridge)
-                }
-                // Intercept emoji download completion: detect real file type, convert video
-                // to GIF if needed, copy to album, show result toast, skip original handler
-                // — otherwise every downloaded emoji is saved as .png with MIME image/png.
-                transaction.add(::installEmojiDownloadedCallbackHook.name) {
-                    installEmojiDownloadedCallbackHook(bridge)
-                }
-                // Fix MediaStore URI creation for converted GIF files: internal logic has a
-                // file-extension whitelist, so non-whitelisted extensions (e.g. gif) fail
-                // createUri and cannot be saved to external storage — this hook falls back
-                // to getImageUri manually and writes into output array.
-                transaction.add(::installCreateUriHook.name) {
-                    installCreateUriHook(bridge)
-                }
-                transaction.commit()
+            // Force "save to album" button visible for emoji comments.
+            transaction.add(::installSaveEmojiToAlbumButtonHook.name) {
+                installSaveEmojiToAlbumButtonHook()
             }
+            // Before the save button's download callback fires, inject emoji URLs into
+            // comment.imageList[0].downloadUrl so the downloader picks them up.
+            // Without it: the downloader fetches nothing because imageList is empty.
+            transaction.add(::installClickSaveEmojiToAlbumButtonCallbackHook.name) {
+                installClickSaveEmojiToAlbumButtonCallbackHook()
+            }
+            // Intercept emoji download completion: detect real file type, convert video
+            // to GIF if needed, copy to album, show result toast, skip original handler
+            // — otherwise every downloaded emoji is saved as .png with MIME image/png.
+            transaction.add(::installEmojiDownloadedCallbackHook.name) {
+                installEmojiDownloadedCallbackHook()
+            }
+            // Fix MediaStore URI creation for converted GIF files: internal logic has a
+            // file-extension whitelist, so non-whitelisted extensions (e.g. gif) fail
+            // createUri and cannot be saved to external storage — this hook falls back
+            // to getImageUri manually and writes into output array.
+            transaction.add(::installCreateUriHook.name) {
+                installCreateUriHook()
+            }
+            transaction.commit()
         }
     }
 
-    private fun installSaveEmojiToAlbumButtonHook(bridge: DexKitBridge): YukiMemberHookCreator.MemberHookCreator.Result? {
+    private fun installSaveEmojiToAlbumButtonHook(): YukiMemberHookCreator.MemberHookCreator.Result? {
         var ret: YukiMemberHookCreator.MemberHookCreator.Result? = null
 
         val packageInstance = DouyinPackage.instance
@@ -104,7 +101,7 @@ object CommentEmojiHooker : YukiBaseHooker() {
         return ret
     }
 
-    private fun installClickSaveEmojiToAlbumButtonCallbackHook(bridge: DexKitBridge): YukiMemberHookCreator.MemberHookCreator.Result? {
+    private fun installClickSaveEmojiToAlbumButtonCallbackHook(): YukiMemberHookCreator.MemberHookCreator.Result? {
         var ret: YukiMemberHookCreator.MemberHookCreator.Result? = null
 
         val packageInstance = DouyinPackage.instance
@@ -180,7 +177,7 @@ object CommentEmojiHooker : YukiBaseHooker() {
         return ret
     }
 
-    private fun installEmojiDownloadedCallbackHook(bridge: DexKitBridge): YukiMemberHookCreator.MemberHookCreator.Result? {
+    private fun installEmojiDownloadedCallbackHook(): YukiMemberHookCreator.MemberHookCreator.Result? {
         var ret: YukiMemberHookCreator.MemberHookCreator.Result? = null
 
         val packageInstance = DouyinPackage.instance
@@ -322,8 +319,7 @@ object CommentEmojiHooker : YukiBaseHooker() {
         return ret
     }
 
-    @Suppress("UNUSED_PARAMETER")
-    private fun installCreateUriHook(unused: DexKitBridge): YukiMemberHookCreator.MemberHookCreator.Result? {
+    private fun installCreateUriHook(): YukiMemberHookCreator.MemberHookCreator.Result? {
         var ret: YukiMemberHookCreator.MemberHookCreator.Result? = null
 
         val packageInstance = DouyinPackage.instance
@@ -360,11 +356,7 @@ object CommentEmojiHooker : YukiBaseHooker() {
                     if (fileMimeType == null) {
                         YLog.error("$TAG: createUri failed, unable to resolve MIME type")
                         return@after
-                    } else if (!(
-                            fileMimeType.startsWith("image/") ||
-                                fileMimeType.startsWith("video/")
-                            )
-                    ) {
+                    } else if (!(fileMimeType.startsWith("image/") || fileMimeType.startsWith("video/"))) {
                         YLog.error(
                             "$TAG: createUri is not allowed for restricted MIME type. mimeType=$fileMimeType"
                         )
@@ -569,13 +561,10 @@ object CommentEmojiHooker : YukiBaseHooker() {
                     if (i + 1 < timestampsUs.size) {
                         timestampsUs[i + 1]
                     } else {
-                        if (i >
-                            0
-                        ) {
+                        if (i > 0) {
                             timestampsUs[i] + (timestampsUs[i] - timestampsUs[i - 1])
                         } else {
-                            currentUs +
-                                100_000L
+                            currentUs + 100_000L
                         }
                     }
 

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/DouyinPackage.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/DouyinPackage.kt
@@ -285,7 +285,7 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
                     Settings.Secure.ANDROID_ID
                 ) ?: "unknown"
             val hookInfoFileName =
-                "${AppProperties.PROJECT_NAMESPACE}-${androidId.hashCode().toUInt()}"
+                "${AppProperties.PROJECT_APPLICATION_ID}-${androidId.hashCode().toUInt()}"
                     .hashCode().toHexString()
             YLog.debug("$TAG: hookInfoFileName: $hookInfoFileName")
 

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/DouyinPackage.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/DouyinPackage.kt
@@ -81,7 +81,6 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
     val commentLongPressItemModel = CommentLongPressItemModelModule()
     val saveImageActionItem = SaveImageActionItemModule()
     val commentExtensionsKt = CommentExtensionsKtModule()
-    val commentSaveToAlbumButtonClick = CommentSaveToAlbumButtonClickModule()
     val commentImageSaveHelper = CommentImageSaveHelperModule()
     val downloadInfo = DownloadInfoModule()
     val digestUtils = DigestUtilsModule()
@@ -162,29 +161,30 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
         fun commentActionParams() = Field(hookInfo.saveImageActionItem.cmtActionParams.nameOrNull)
 
         fun saveImageActionParams() = Field(hookInfo.saveImageActionItem.saveImgActionParams.nameOrNull)
+
+        inner class OnClickExecutorModule {
+            val selfClass by weak {
+                hookInfo.saveImageActionItem.onClickExecutor.class_.nameOrNull?.toClass(classLoader)
+            }
+
+            fun onClick() = Method(
+                hookInfo.saveImageActionItem.onClickExecutor.onClick.nameOrNull,
+                hookInfo.saveImageActionItem.onClickExecutor.onClick.parameters.valuesListOrNull
+            )
+        }
+
+        val onClickExecutor = OnClickExecutorModule()
     }
 
     inner class CommentExtensionsKtModule {
         val selfClass by weak {
-            hookInfo.cmtSaveToAlbumBtnVisibility.class_.nameOrNull
+            hookInfo.commentExtensionKt.class_.nameOrNull
                 ?.toClass(classLoader)
         }
 
-        fun saveToAlbumVisibility() = Method(
-            hookInfo.cmtSaveToAlbumBtnVisibility.checkVisibility.nameOrNull,
-            hookInfo.cmtSaveToAlbumBtnVisibility.checkVisibility.parameters.valuesListOrNull
-        )
-    }
-
-    inner class CommentSaveToAlbumButtonClickModule {
-        val selfClass by weak {
-            hookInfo.cmtSaveToAlbumBtnClickedCallback.class_.nameOrNull
-                ?.toClass(classLoader)
-        }
-
-        fun onClicked() = Method(
-            hookInfo.cmtSaveToAlbumBtnClickedCallback.clickedCallback.nameOrNull,
-            hookInfo.cmtSaveToAlbumBtnClickedCallback.clickedCallback.parameters.valuesListOrNull
+        fun hasValidImageUrl() = Method(
+            hookInfo.commentExtensionKt.hasValidImageUrl.nameOrNull,
+            hookInfo.commentExtensionKt.hasValidImageUrl.parameters.valuesListOrNull
         )
     }
 
@@ -557,7 +557,18 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
                                         type = "com.ss.android.ugc.aweme.comment.CommentActionParams"
                                     }?.self
                                     ?.name
-                            if (cmtActionParamsFieldName == null || saveImageActionParamsFieldName == null) {
+                            val onClickMethodData = bridge
+                                .findMethod {
+                                    matcher {
+                                        modifiers = Modifier.STATIC + Modifier.FINAL + Modifier.PUBLIC
+                                        returnType = "java.lang.Object"
+                                        params {
+                                            count = 1
+                                        }
+                                        addUsingString("bpea-comment_save_image_to_album")
+                                    }
+                                }.singleOrNull()
+                            if (cmtActionParamsFieldName == null || saveImageActionParamsFieldName == null || onClickMethodData == null) {
                                 YLog.error(
                                     "$TAG: Unable to populate ${this::class.simpleName} config, possibly due to unfound obfuscated methods"
                                 )
@@ -576,99 +587,71 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
                                 field {
                                     name = saveImageActionParamsFieldName
                                 }
+                            onClickExecutor = saveImageActionItemOnClickExecutor {
+                                class_ = class_ {
+                                    name = onClickMethodData.className
+                                }
+                                onClick = method {
+                                    name = onClickMethodData.methodName
+                                    parameters = MethodKt.parameters {
+                                        values.clear()
+                                        values.addAll(onClickMethodData.paramTypeNames)
+                                    }
+                                }
+                            }
                         }.onFailure {
                             YLog.error("$TAG: Unable to populate config", it)
                         }
                     }
 
-                cmtSaveToAlbumBtnVisibility =
-                    cmtSaveToAlbumBtnVisibility {
-                        runCatching {
-                            bridge
-                                .findMethod {
-                                    matcher {
-                                        modifiers = Modifier.STATIC
-                                        params {
-                                            add("com.ss.android.ugc.aweme.comment.model.Comment")
-                                            add("int")
+                commentExtensionKt = commentExtensionKt {
+                    runCatching {
+                        bridge.findMethod {
+                            matcher {
+                                modifiers = Modifier.PUBLIC or Modifier.STATIC or Modifier.FINAL
+                                declaredClass = "com.ss.android.ugc.aweme.comment.util.CommentExtensionsKt"
+                                returnType = "boolean"
+                                params {
+                                    add("com.ss.android.ugc.aweme.comment.model.Comment")
+                                    add("int")
+                                }
+                                invokeMethods {
+                                    add {
+                                        declaredClass =
+                                            "com.ss.android.ugc.aweme.comment.model.CommentImageStruct"
+                                        returnType = "com.ss.android.ugc.aweme.base.model.UrlModel"
+                                        paramCount = 0
+                                        addUsingField {
+                                            name = "downloadUrl"
                                         }
-                                        returnType = "boolean"
-                                        invokeMethods {
-                                            add {
-                                                declaredClass =
-                                                    "com.ss.android.ugc.aweme.comment.model.CommentImageStruct"
-                                                returnType = "com.ss.android.ugc.aweme.base.model.UrlModel"
-                                                paramCount = 0
-                                                addUsingField {
-                                                    name = "downloadUrl"
-                                                }
+                                    }
+                                }
+                            }
+                        }.singleOrNull()
+                            ?.also { match ->
+                                class_ =
+                                    class_ {
+                                        name = match.className
+                                    }
+                                hasValidImageUrl =
+                                    method {
+                                        name = match.methodName
+                                        parameters =
+                                            MethodKt.parameters {
+                                                values.clear()
+                                                values.addAll(match.paramTypeNames)
                                             }
-                                        }
                                     }
-                                }.singleOrNull()
-                                ?.also { match ->
-                                    class_ =
-                                        class_ {
-                                            name = match.className
-                                        }
-                                    checkVisibility =
-                                        method {
-                                            name = match.methodName
-                                            parameters =
-                                                MethodKt.parameters {
-                                                    values.clear()
-                                                    values.addAll(match.paramTypeNames)
-                                                }
-                                        }
-                                } ?: run {
-                                YLog.error(
-                                    "$TAG: Unable to populate ${this::class.simpleName} config, possibly due to unfound obfuscated methods"
-                                )
-                                return@cmtSaveToAlbumBtnVisibility
-                            }
-                        }.onFailure {
-                            YLog.error("$TAG: Unable to populate config", it)
+                            } ?: run {
+                            YLog.error(
+                                "$TAG: Unable to populate ${this::class.simpleName} config, possibly due to unfound obfuscated methods"
+                            )
+                            return@commentExtensionKt
                         }
+                    }.onFailure {
+                        YLog.error("$TAG: Unable to populate config", it)
                     }
-
-                cmtSaveToAlbumBtnClickedCallback =
-                    cmtSaveToAlbumBtnClickedCallback {
-                        runCatching {
-                            bridge
-                                .findMethod {
-                                    matcher {
-                                        modifiers = Modifier.STATIC + Modifier.FINAL + Modifier.PUBLIC
-                                        returnType = "java.lang.Object"
-                                        params {
-                                            count = 1
-                                        }
-                                        addUsingString("bpea-comment_save_image_to_album")
-                                    }
-                                }.singleOrNull()
-                                ?.also { match ->
-                                    class_ =
-                                        class_ {
-                                            name = match.className
-                                        }
-                                    clickedCallback =
-                                        method {
-                                            name = match.methodName
-                                            parameters =
-                                                MethodKt.parameters {
-                                                    values.clear()
-                                                    values.addAll(match.paramTypeNames)
-                                                }
-                                        }
-                                } ?: run {
-                                YLog.error(
-                                    "$TAG: Unable to populate ${this::class.simpleName} config, possibly due to unfound obfuscated methods"
-                                )
-                                return@cmtSaveToAlbumBtnClickedCallback
-                            }
-                        }.onFailure {
-                            YLog.error("$TAG: Unable to populate config", it)
-                        }
-                    }
+                }
 
                 commentImageSaveHelper =
                     commentImageSaveHelper {

--- a/app/src/main/proto/io/github/twyora/douyinenhancer/hook/configs.proto
+++ b/app/src/main/proto/io/github/twyora/douyinenhancer/hook/configs.proto
@@ -57,10 +57,16 @@ message CommentLongPressItemModel {
   optional Field comment_action_params = 2;
 }
 
+message SaveImageActionItemOnClickExecutor{
+  optional Class  class    = 1;
+  optional Method on_click = 2;
+}
+
 message SaveImageActionItem {
-  optional Class class                  = 1;
-  optional Field cmt_action_params      = 2;
-  optional Field save_img_action_params = 3;
+  optional Class                              class                  = 1;
+  optional Field                              cmt_action_params      = 2;
+  optional Field                              save_img_action_params = 3;
+  optional SaveImageActionItemOnClickExecutor on_click_executor      = 4;
 }
 
 message TokenCert{
@@ -88,9 +94,9 @@ message UGFileUtilsKt {
   optional Method create_uri               = 7;
 }
 
-message CmtSaveToAlbumBtnVisibility{
-  optional Class  class            = 1;
-  optional Method check_visibility = 2;
+message CommentExtensionKt{
+  optional Class  class               = 1;
+  optional Method has_valid_image_url = 2;
 }
 
 message CmtSaveToAlbumBtnClickedCallback{
@@ -111,18 +117,17 @@ message HookInfo {
   uint32 host_version_code   = 4;
   uint32 generation          = 5;
 
-  optional CommentImageStruct               comment_image_struct                   = 6;
-  optional UrlModel                         url_model                              = 7;
-  optional Comment                          comment                                = 8;
-  optional Emoji                            emoji                                  = 9;
-  optional CommentActionParams              comment_action_params                  = 10;
-  optional CommentLongPressItemModel        comment_long_press_item_model          = 11;
-  optional SaveImageActionItem              save_image_action_item                 = 12;
-  optional CmtSaveToAlbumBtnVisibility      cmt_save_to_album_btn_visibility       = 13;
-  optional CmtSaveToAlbumBtnClickedCallback cmt_save_to_album_btn_clicked_callback = 14;
-  optional CommentImageSaveHelper           comment_image_save_helper              = 15;
-  optional DownloadInfo                     download_info                          = 16;
-  optional DigestUtils                      digest_utils                           = 17;
-  optional UGFileUtilsKt                    ug_file_utils                          = 18;
-  optional TokenCert                        token_cert                             = 19;
+  optional CommentImageStruct        comment_image_struct          = 6;
+  optional UrlModel                  url_model                     = 7;
+  optional Comment                   comment                       = 8;
+  optional Emoji                     emoji                         = 9;
+  optional CommentActionParams       comment_action_params         = 10;
+  optional CommentLongPressItemModel comment_long_press_item_model = 11;
+  optional SaveImageActionItem       save_image_action_item        = 12;
+  optional CommentExtensionKt        comment_extension_kt          = 13;
+  optional CommentImageSaveHelper    comment_image_save_helper     = 14;
+  optional DownloadInfo              download_info                 = 15;
+  optional DigestUtils               digest_utils                  = 16;
+  optional UGFileUtilsKt             ug_file_utils                 = 17;
+  optional TokenCert                 token_cert                    = 18;
 }


### PR DESCRIPTION
- Reorganize proto hook info fields
- Switch hook info file naming from namespace to applicationId
- Drop DexKitBridge parameter from CommentEmojiHooker hook functions, use DouyinPackage references instead
