### PR TITLE
fix: correct typo in UGFileUtilsKtModule class name

### DIFF
--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/DouyinPackage.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/DouyinPackage.kt
@@ -84,7 +84,7 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
     val commentImageSaveHelper = CommentImageSaveHelperModule()
     val downloadInfo = DownloadInfoModule()
     val digestUtils = DigestUtilsModule()
-    val ugFileUtils = UGFileUiltsKtModule()
+    val ugFileUtils = UGFileUtilsKtModule()
     val tokenCert = TokenCertModule()
 
     inner class CommentImageStructModule {
@@ -231,7 +231,7 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
         )
     }
 
-    inner class UGFileUiltsKtModule {
+    inner class UGFileUtilsKtModule {
         val selfClass by weak {
             hookInfo.ugFileUtils.class_.nameOrNull
                 ?.toClass(classLoader)


### PR DESCRIPTION
Fix typo in inner class and val declaration to UGFileUtilsKtModule