### PR TITLE
ci: remove paths filter from spotless workflow

### DIFF
--- a/.github/workflows/spotless_check.yml
+++ b/.github/workflows/spotless_check.yml
@@ -3,11 +3,6 @@ name: Spotless Format Check
 on:
   pull_request:
     branches: [ "main" ]
-    paths:
-      - 'app/src/**'
-      - '**.gradle'
-      - '**.gradle.kts'
-      - 'gradle.properties'
 
 permissions:
     contents: read


### PR DESCRIPTION
## Problem
Currently, the `spotless_check` workflow uses a `paths` filter to only trigger when specific source files are modified, because I didn't want 
to run the spotless check on every single PR. However, `spotless` is configured as a **required status check** in the repository's branch protection rules. 

When a PR modifies files that are not included in the `paths` filter, the workflow is skipped. Since the merge operation requires the 
spotless check to pass, the PR gets stuck in a deadlock.

## Solution
I simply removed the `paths` filter from the `on.pull_request` trigger in the spotless workflow. This ensures that the `spotless` job is always triggered for every PR targeting `main`, allowing it to report a successful status and unblocking the merge process. As a result, the spotless check will now run on all PRs, regardless of the modified files.