### PR TITLE
refactor: organize settings keys by domain

### DIFF
--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/CommentEmojiHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/CommentEmojiHooker.kt
@@ -13,6 +13,7 @@ import com.highcapable.yukihookapi.hook.entity.YukiBaseHooker
 import com.highcapable.yukihookapi.hook.log.YLog
 import com.shakster.gifkt.GifEncoder
 import io.github.twyora.douyinenhancer.config.FastKVConfigManager
+import io.github.twyora.douyinenhancer.config.key.SaveKey
 import io.github.twyora.douyinenhancer.hook.utils.FileTypeDetector
 import io.github.twyora.douyinenhancer.hook.utils.HookTransaction
 import io.github.twyora.douyinenhancer.hook.utils.getField
@@ -32,7 +33,7 @@ object CommentEmojiHooker : YukiBaseHooker() {
     private val TAG = this::class.simpleName
 
     override fun onHook() {
-        if (!FastKVConfigManager.settings.getBoolean("unlock_comment_emoji", false)) {
+        if (!FastKVConfigManager.settings.getBoolean(SaveKey.UNLOCK_COMMENT_EMOJI, false)) {
             return
         }
 

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/CommentImageHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/CommentImageHooker.kt
@@ -3,6 +3,7 @@ package io.github.twyora.douyinenhancer.hook
 import com.highcapable.yukihookapi.hook.entity.YukiBaseHooker
 import com.highcapable.yukihookapi.hook.log.YLog
 import io.github.twyora.douyinenhancer.config.FastKVConfigManager
+import io.github.twyora.douyinenhancer.config.key.SaveKey
 import io.github.twyora.douyinenhancer.hook.utils.getField
 import io.github.twyora.douyinenhancer.hook.utils.resolveMethod
 
@@ -10,7 +11,7 @@ object CommentImageHooker : YukiBaseHooker() {
     private val TAG = this::class.simpleName
 
     override fun onHook() {
-        if (!FastKVConfigManager.settings.getBoolean("purify_comment_image", false)) {
+        if (!FastKVConfigManager.settings.getBoolean(SaveKey.PURIFY_COMMENT_IMAGE, false)) {
             return
         }
 

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/RecommendedFeedHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/RecommendedFeedHooker.kt
@@ -3,6 +3,7 @@ package io.github.twyora.douyinenhancer.hook
 import com.highcapable.yukihookapi.hook.entity.YukiBaseHooker
 import com.highcapable.yukihookapi.hook.log.YLog
 import io.github.twyora.douyinenhancer.config.FastKVConfigManager
+import io.github.twyora.douyinenhancer.config.key.RecommendedFeedFilterKey
 import io.github.twyora.douyinenhancer.hook.utils.getField
 import io.github.twyora.douyinenhancer.hook.utils.invokeMethod
 import io.github.twyora.douyinenhancer.hook.utils.resolveMethod
@@ -11,29 +12,29 @@ object RecommendedFeedHooker : YukiBaseHooker() {
     private val TAG = this::class.simpleName
 
     private val blockAdEnabled by lazy {
-        FastKVConfigManager.settings.getBoolean("recommended_feed_filter_block_ad", false)
+        FastKVConfigManager.settings.getBoolean(RecommendedFeedFilterKey.BLOCK_AD, false)
     }
 
     private val blockEcomEnabled by lazy {
-        FastKVConfigManager.settings.getBoolean("recommended_feed_filter_block_ecom_aweme", false)
+        FastKVConfigManager.settings.getBoolean(RecommendedFeedFilterKey.BLOCK_ECOM, false)
     }
 
     private val blockGrouponLargeCardEnabled by lazy {
-        FastKVConfigManager.settings.getBoolean("recommended_feed_filter_block_groupon_large_card", false)
+        FastKVConfigManager.settings.getBoolean(RecommendedFeedFilterKey.BLOCK_GROUPON, false)
     }
 
     private val hideShortDurationLimit by lazy {
-        FastKVConfigManager.settings.getInt("recommended_feed_filter_hide_short_duration_limit", 0)
+        FastKVConfigManager.settings.getInt(RecommendedFeedFilterKey.SHORT_DURATION_LIMIT, 0)
     }
     private val hideLongDurationLimit by lazy {
-        FastKVConfigManager.settings.getInt("recommended_feed_filter_hide_long_duration_limit", Int.MAX_VALUE)
+        FastKVConfigManager.settings.getInt(RecommendedFeedFilterKey.LONG_DURATION_LIMIT, Int.MAX_VALUE)
     }
 
     private val kwdFilterTitleRegexMode by lazy {
-        FastKVConfigManager.settings.getBoolean("recommended_feed_filter_title_regex_mode", false)
+        FastKVConfigManager.settings.getBoolean(RecommendedFeedFilterKey.TITLE_REGEX_MODE, false)
     }
     private val kwdFilterTitleRegexes by lazy {
-        val titleList = FastKVConfigManager.settings.getStringSet("recommended_feed_filter_group_aweme_title", null)
+        val titleList = FastKVConfigManager.settings.getStringSet(RecommendedFeedFilterKey.TITLE_KEYWORDS, null)
         if (kwdFilterTitleRegexMode) {
             titleList?.map {
                 it.toRegex()
@@ -46,18 +47,18 @@ object RecommendedFeedHooker : YukiBaseHooker() {
     }
 
     private val kwdFilterAuthorUid by lazy {
-        FastKVConfigManager.settings.getStringSet("recommended_feed_filter_group_author_uid", null)
+        FastKVConfigManager.settings.getStringSet(RecommendedFeedFilterKey.AUTHOR_UID_KEYWORDS, null)
     }
 
     private val kwdFilterAuthorNicknames by lazy {
-        FastKVConfigManager.settings.getStringSet("recommended_feed_filter_group_author_nickname", null)
+        FastKVConfigManager.settings.getStringSet(RecommendedFeedFilterKey.AUTHOR_NICKNAME_KEYWORDS, null)
     }
 
     private val kwdFilterDescRegexMode by lazy {
-        FastKVConfigManager.settings.getBoolean("recommended_feed_filter_desc_regex_mode", false)
+        FastKVConfigManager.settings.getBoolean(RecommendedFeedFilterKey.DESC_REGEX_MODE, false)
     }
     private val kwdFilterDescRegexes by lazy {
-        val descList = FastKVConfigManager.settings.getStringSet("recommended_feed_filter_group_aweme_desc", null)
+        val descList = FastKVConfigManager.settings.getStringSet(RecommendedFeedFilterKey.DESC_KEYWORDS, null)
         if (kwdFilterDescRegexMode) {
             descList?.map { it.toRegex() }
         } else {

--- a/app/src/main/java/io/github/twyora/douyinenhancer/ui/RecommendedFeedFilterDialog.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/ui/RecommendedFeedFilterDialog.kt
@@ -12,6 +12,8 @@ import androidx.core.content.edit
 import androidx.core.view.children
 import io.github.twyora.douyinenhancer.R
 import io.github.twyora.douyinenhancer.config.FastKVConfigManager
+import io.github.twyora.douyinenhancer.config.key.MiscKey
+import io.github.twyora.douyinenhancer.config.key.RecommendedFeedFilterKey
 import io.github.twyora.douyinenhancer.databinding.ItemInputWithDeleteBinding
 import io.github.twyora.douyinenhancer.databinding.RecommendedFeedFilterDialogBinding
 
@@ -23,7 +25,7 @@ class RecommendedFeedFilterDialog(context: Context) : AlertDialog.Builder(contex
         val prefs = FastKVConfigManager.settings
 
         // Show hidden block options when feature is enabled
-        val showBlockGroups = prefs.getBoolean("enable_hidden_features", false)
+        val showBlockGroups = prefs.getBoolean(MiscKey.ENABLE_HIDDEN_FEATURES, false)
         if (showBlockGroups) {
             recommendedFeedFilterDialogBinding.groupBlockAd.visibility = View.VISIBLE
             recommendedFeedFilterDialogBinding.groupBlockEcomAweme.visibility = View.VISIBLE
@@ -31,36 +33,36 @@ class RecommendedFeedFilterDialog(context: Context) : AlertDialog.Builder(contex
         }
 
         // restore state
-        recommendedFeedFilterDialogBinding.switchBlockAd.isChecked = prefs.getBoolean("recommended_feed_filter_block_ad", false)
+        recommendedFeedFilterDialogBinding.switchBlockAd.isChecked = prefs.getBoolean(RecommendedFeedFilterKey.BLOCK_AD, false)
         recommendedFeedFilterDialogBinding.switchBlockEcomAweme.isChecked =
-            prefs.getBoolean("recommended_feed_filter_block_ecom_aweme", false)
+            prefs.getBoolean(RecommendedFeedFilterKey.BLOCK_ECOM, false)
         recommendedFeedFilterDialogBinding.switchBlockGrouponLargeCard.isChecked =
-            prefs.getBoolean("recommended_feed_filter_block_groupon_large_card", false)
-        prefs.getInt("recommended_feed_filter_hide_short_duration_limit", 0).let {
+            prefs.getBoolean(RecommendedFeedFilterKey.BLOCK_GROUPON, false)
+        prefs.getInt(RecommendedFeedFilterKey.SHORT_DURATION_LIMIT, 0).let {
             recommendedFeedFilterDialogBinding.editShortDuration.setText(it.toString())
         }
-        prefs.getInt("recommended_feed_filter_hide_long_duration_limit", Int.MAX_VALUE).let {
+        prefs.getInt(RecommendedFeedFilterKey.LONG_DURATION_LIMIT, Int.MAX_VALUE).let {
             recommendedFeedFilterDialogBinding.editLongDuration.setText(it.toString())
         }
-        recommendedFeedFilterDialogBinding.switchTitleRegex.isChecked = prefs.getBoolean("recommended_feed_filter_title_regex_mode", false)
-        prefs.getStringSet("recommended_feed_filter_group_aweme_title", null)?.forEach {
+        recommendedFeedFilterDialogBinding.switchTitleRegex.isChecked = prefs.getBoolean(RecommendedFeedFilterKey.TITLE_REGEX_MODE, false)
+        prefs.getStringSet(RecommendedFeedFilterKey.TITLE_KEYWORDS, null)?.forEach {
             pushKeywordItem(context, recommendedFeedFilterDialogBinding.groupAwemeTitle).apply {
                 editInput.setText(it)
             }
         }
-        prefs.getStringSet("recommended_feed_filter_group_author_uid", null)?.forEach {
+        prefs.getStringSet(RecommendedFeedFilterKey.AUTHOR_UID_KEYWORDS, null)?.forEach {
             pushKeywordItem(context, recommendedFeedFilterDialogBinding.groupAuthorUid).apply {
                 editInput.inputType = InputType.TYPE_CLASS_NUMBER
                 editInput.setText(it)
             }
         }
-        prefs.getStringSet("recommended_feed_filter_group_author_nickname", null)?.forEach {
+        prefs.getStringSet(RecommendedFeedFilterKey.AUTHOR_NICKNAME_KEYWORDS, null)?.forEach {
             pushKeywordItem(context, recommendedFeedFilterDialogBinding.groupAuthorNickname).apply {
                 editInput.setText(it)
             }
         }
-        recommendedFeedFilterDialogBinding.switchDescRegex.isChecked = prefs.getBoolean("recommended_feed_filter_desc_regex_mode", false)
-        prefs.getStringSet("recommended_feed_filter_group_aweme_desc", null)?.forEach {
+        recommendedFeedFilterDialogBinding.switchDescRegex.isChecked = prefs.getBoolean(RecommendedFeedFilterKey.DESC_REGEX_MODE, false)
+        prefs.getStringSet(RecommendedFeedFilterKey.DESC_KEYWORDS, null)?.forEach {
             pushKeywordItem(context, recommendedFeedFilterDialogBinding.groupAwemeDesc).apply {
                 editInput.setText(it)
             }
@@ -141,17 +143,17 @@ class RecommendedFeedFilterDialog(context: Context) : AlertDialog.Builder(contex
             }
 
             prefs.edit(commit = true) {
-                putBoolean("recommended_feed_filter_block_ad", blockAd)
-                putBoolean("recommended_feed_filter_block_ecom_aweme", blockEcomAweme)
-                putBoolean("recommended_feed_filter_block_groupon_large_card", blockGrouponLargeCard)
-                putInt("recommended_feed_filter_hide_short_duration_limit", hideShortDurationLimit)
-                putInt("recommended_feed_filter_hide_long_duration_limit", hideLongDurationLimit)
-                putBoolean("recommended_feed_filter_title_regex_mode", titleRegexMode)
-                putStringSet("recommended_feed_filter_group_aweme_title", titleKeywords)
-                putStringSet("recommended_feed_filter_group_author_uid", uidKeywords)
-                putStringSet("recommended_feed_filter_group_author_nickname", upKeywords)
-                putBoolean("recommended_feed_filter_desc_regex_mode", descRegexMode)
-                putStringSet("recommended_feed_filter_group_aweme_desc", descKeywords)
+                putBoolean(RecommendedFeedFilterKey.BLOCK_AD, blockAd)
+                putBoolean(RecommendedFeedFilterKey.BLOCK_ECOM, blockEcomAweme)
+                putBoolean(RecommendedFeedFilterKey.BLOCK_GROUPON, blockGrouponLargeCard)
+                putInt(RecommendedFeedFilterKey.SHORT_DURATION_LIMIT, hideShortDurationLimit)
+                putInt(RecommendedFeedFilterKey.LONG_DURATION_LIMIT, hideLongDurationLimit)
+                putBoolean(RecommendedFeedFilterKey.TITLE_REGEX_MODE, titleRegexMode)
+                putStringSet(RecommendedFeedFilterKey.TITLE_KEYWORDS, titleKeywords)
+                putStringSet(RecommendedFeedFilterKey.AUTHOR_UID_KEYWORDS, uidKeywords)
+                putStringSet(RecommendedFeedFilterKey.AUTHOR_NICKNAME_KEYWORDS, upKeywords)
+                putBoolean(RecommendedFeedFilterKey.DESC_REGEX_MODE, descRegexMode)
+                putStringSet(RecommendedFeedFilterKey.DESC_KEYWORDS, descKeywords)
             }
 
             (context as? Activity)?.runOnUiThread {

--- a/app/src/main/java/io/github/twyora/douyinenhancer/ui/SettingsDialog.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/ui/SettingsDialog.kt
@@ -15,6 +15,7 @@ import com.highcapable.yukihookapi.hook.factory.injectModuleAppResources
 import com.highcapable.yukihookapi.hook.log.YLog
 import io.github.twyora.douyinenhancer.R
 import io.github.twyora.douyinenhancer.config.FastKVConfigManager
+import io.github.twyora.douyinenhancer.config.key.MiscKey
 import io.github.twyora.douyinenhancer.generated.AppProperties
 import io.github.twyora.douyinenhancer.hook.DouyinPackage
 import io.github.twyora.douyinenhancer.hook.utils.setField
@@ -41,10 +42,10 @@ class SettingsDialog(context: Context) : AlertDialog.Builder(context) {
             preferenceManager.setField<Any?>(DouyinPackage.Field("mEditor"), null)
             addPreferencesFromResource(R.xml.prefs_setting)
 
-            if (!prefs.getBoolean("enable_hidden_features", false)) {
+            if (!prefs.getBoolean(MiscKey.ENABLE_HIDDEN_FEATURES, false)) {
                 val miscCategory = findPreference("pref_category_misc") as? PreferenceCategory
                 miscCategory?.let { category ->
-                    findPreference("enable_hidden_features")?.let {
+                    findPreference(MiscKey.ENABLE_HIDDEN_FEATURES)?.let {
                         category.removePreference(it)
                     }
                     if (category.preferenceCount == 0) {
@@ -67,10 +68,10 @@ class SettingsDialog(context: Context) : AlertDialog.Builder(context) {
 
             "version" -> {
                 val prefs = FastKVConfigManager.settings
-                if (!prefs.getBoolean("enable_hidden_features", false)) {
+                if (!prefs.getBoolean(MiscKey.ENABLE_HIDDEN_FEATURES, false)) {
                     if (++hiddenFeatureClickCount == 10) {
                         prefs.edit(commit = true) {
-                            putBoolean("enable_hidden_features", true)
+                            putBoolean(MiscKey.ENABLE_HIDDEN_FEATURES, true)
                         }
                         activity.runOnUiThread {
                             Toast.makeText(


### PR DESCRIPTION
Group scattered preference key constants into domain-specific files under config/key/, reducing coupling and improving discoverability.
