### PR TITLE
fix: version info uses stale base values instead of flavor-specific values

### DIFF
--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/DouyinPackage.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/DouyinPackage.kt
@@ -11,6 +11,7 @@ import com.highcapable.kavaref.KavaRef.Companion.resolve
 import com.highcapable.kavaref.condition.type.Modifiers
 import com.highcapable.kavaref.extension.toClass
 import com.highcapable.yukihookapi.hook.log.YLog
+import io.github.twyora.douyinenhancer.BuildConfig
 import io.github.twyora.douyinenhancer.generated.AppProperties
 import io.github.twyora.douyinenhancer.hook.utils.weak
 import java.io.File
@@ -491,8 +492,8 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
                 if (hookInfo.lastUpdateTime >= moduleLastUpdateTime &&
                     hookInfo.lastUpdateTime >= hostAppLastUpdateTime &&
                     hookInfo.hostVersionCode == hostAppVersionCode &&
-                    hookInfo.moduleVersionCode == AppProperties.PROJECT_VERSION_CODE &&
-                    hookInfo.moduleVersionName == AppProperties.PROJECT_VERSION_NAME
+                    hookInfo.moduleVersionCode == BuildConfig.VERSION_CODE &&
+                    hookInfo.moduleVersionName == BuildConfig.VERSION_NAME
                 ) {
                     return hookInfo
                 } else {
@@ -532,8 +533,8 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
                             ).lastUpdateTime
                     }.getOrDefault(hostAppPackageInfo.lastUpdateTime)
                 )
-            moduleVersionCode = AppProperties.PROJECT_VERSION_CODE
-            moduleVersionName = AppProperties.PROJECT_VERSION_NAME
+            moduleVersionCode = BuildConfig.VERSION_CODE
+            moduleVersionName = BuildConfig.VERSION_NAME
             hostVersionCode = hostAppPackageInfo.versionCode
             generation = 0
 

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/DouyinPackage.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/DouyinPackage.kt
@@ -477,7 +477,7 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
                     runCatching {
                         context.packageManager
                             .getPackageInfo(
-                                AppProperties.PROJECT_NAMESPACE,
+                                AppProperties.PROJECT_APPLICATION_ID,
                                 0
                             ).lastUpdateTime
                     }.getOrDefault(hostAppLastUpdateTime)

--- a/app/src/main/java/io/github/twyora/douyinenhancer/ui/SettingsDialog.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/ui/SettingsDialog.kt
@@ -13,6 +13,7 @@ import android.widget.Toast
 import androidx.core.content.edit
 import com.highcapable.yukihookapi.hook.factory.injectModuleAppResources
 import com.highcapable.yukihookapi.hook.log.YLog
+import io.github.twyora.douyinenhancer.BuildConfig
 import io.github.twyora.douyinenhancer.R
 import io.github.twyora.douyinenhancer.config.FastKVConfigManager
 import io.github.twyora.douyinenhancer.config.key.MiscKey
@@ -54,7 +55,7 @@ class SettingsDialog(context: Context) : AlertDialog.Builder(context) {
                 }
             }
 
-            findPreference("version")?.summary = AppProperties.PROJECT_VERSION_NAME
+            findPreference("version")?.summary = BuildConfig.VERSION_NAME
             findPreference("version")?.onPreferenceClickListener = this
             findPreference("recommend_feed_filter")?.onPreferenceClickListener = this
         }


### PR DESCRIPTION
## What

`AppProperties.PROJECT_VERSION_CODE` and `PROJECT_VERSION_NAME` always return base values from `gradle.properties`, ignoring per-flavor overrides. This causes hook info cache validation mismatches and settings UI to show wrong version info for non-default build variants

## Why

Gropify is a global singleton that reads properties once from `gradle.properties` at configuration time and generates `AppProperties`. When `versionCode`/`versionName` are overridden in `productFlavors`, those changes only affect Android Gradle Plugin's `ProductFlavor` layer. There is no sync mechanism back to Gropify, and since it's a global singleton, it cannot hold per-flavor values — multiple flavor configs would simply overwrite each other, leaving only the last one

## Fix

Switch from Gropify-generated `AppProperties` to Android's built-in `BuildConfig`, which correctly reflects the active build variant's flavor-specific values

Fixes #31 