### PR TITLE
fix: restore Companion imports corrupted by AS Move Package refactoring

### DIFF
--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/comment/CommentEmojiHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/comment/CommentEmojiHooker.kt
@@ -8,7 +8,7 @@ import android.media.MediaMetadataRetriever
 import android.net.Uri
 import android.os.Build
 import android.webkit.MimeTypeMap
-import com.highcapable.kavaref.KavaRef.asResolver
+import com.highcapable.kavaref.KavaRef.Companion.asResolver
 import com.highcapable.yukihookapi.hook.core.YukiMemberHookCreator
 import com.highcapable.yukihookapi.hook.entity.YukiBaseHooker
 import com.highcapable.yukihookapi.hook.log.YLog
@@ -26,11 +26,11 @@ import io.github.twyora.douyinenhancer.utils.invokeStaticMethod
 import io.github.twyora.douyinenhancer.utils.resolveMethod
 import io.github.twyora.douyinenhancer.utils.setField
 import java.io.File
-import kotlin.time.Duration.milliseconds
 import kotlinx.io.Sink
 import kotlinx.io.buffered
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
+import kotlin.time.Duration.Companion.milliseconds
 
 @HookOnMainProcess
 object CommentEmojiHooker : YukiBaseHooker() {

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/comment/CommentEmojiHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/comment/CommentEmojiHooker.kt
@@ -26,11 +26,11 @@ import io.github.twyora.douyinenhancer.utils.invokeStaticMethod
 import io.github.twyora.douyinenhancer.utils.resolveMethod
 import io.github.twyora.douyinenhancer.utils.setField
 import java.io.File
+import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.io.Sink
 import kotlinx.io.buffered
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
-import kotlin.time.Duration.Companion.milliseconds
 
 @HookOnMainProcess
 object CommentEmojiHooker : YukiBaseHooker() {


### PR DESCRIPTION
### Summary

Android Studio's "Move Package" refactoring silently stripped `.Companion` from extension function/property imports in `CommentEmojiHooker.kt`:

- `KavaRef.asResolver` → restored to `KavaRef.Companion.asResolver`
- `Duration.milliseconds` → restored to `Duration.Companion.milliseconds`
