### PR TITLE
refactor: remove redundant withProcess from sub-hookers

### DIFF
--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/comment/CommentAudioHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/comment/CommentAudioHooker.kt
@@ -28,24 +28,22 @@ object CommentAudioHooker : YukiBaseHooker() {
             return
         }
 
-        withProcess(name = mainProcessName) {
-            val transaction = HookTransaction(TAG)
+        val transaction = HookTransaction(TAG)
 
-            transaction.add(::installForceSaveImageVisibleHook.name) {
-                installForceSaveImageVisibleHook()
-            }
-            transaction.add(::installAddSaveImageToWhiteListHook.name) {
-                installAddSaveImageToWhiteListHook()
-            }
-            transaction.add(::installInjectAudioUrlOnSaveClickHook.name) {
-                installInjectAudioUrlOnSaveClickHook()
-            }
-            transaction.add(::installSaveDownloadedAudioHook.name) {
-                installSaveDownloadedAudioHook()
-            }
-
-            transaction.commit()
+        transaction.add(::installForceSaveImageVisibleHook.name) {
+            installForceSaveImageVisibleHook()
         }
+        transaction.add(::installAddSaveImageToWhiteListHook.name) {
+            installAddSaveImageToWhiteListHook()
+        }
+        transaction.add(::installInjectAudioUrlOnSaveClickHook.name) {
+            installInjectAudioUrlOnSaveClickHook()
+        }
+        transaction.add(::installSaveDownloadedAudioHook.name) {
+            installSaveDownloadedAudioHook()
+        }
+
+        transaction.commit()
     }
 
     private fun installForceSaveImageVisibleHook(): YukiMemberHookCreator.MemberHookCreator.Result? {

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/comment/CommentEmojiHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/comment/CommentEmojiHooker.kt
@@ -41,33 +41,31 @@ object CommentEmojiHooker : YukiBaseHooker() {
             return
         }
 
-        withProcess(mainProcessName) {
-            val transaction = HookTransaction(TAG)
-            // Force "save to album" button visible for emoji comments.
-            transaction.add(::installSaveEmojiToAlbumButtonHook.name) {
-                installSaveEmojiToAlbumButtonHook()
-            }
-            // Before the save button's download callback fires, inject emoji URLs into
-            // comment.imageList[0].downloadUrl so the downloader picks them up.
-            // Without it: the downloader fetches nothing because imageList is empty.
-            transaction.add(::installClickSaveEmojiToAlbumButtonCallbackHook.name) {
-                installClickSaveEmojiToAlbumButtonCallbackHook()
-            }
-            // Intercept emoji download completion: detect real file type, convert video
-            // to GIF if needed, copy to album, show result toast, skip original handler
-            // — otherwise every downloaded emoji is saved as .png with MIME image/png.
-            transaction.add(::installEmojiDownloadedCallbackHook.name) {
-                installEmojiDownloadedCallbackHook()
-            }
-            // Fix MediaStore URI creation for converted GIF files: internal logic has a
-            // file-extension whitelist, so non-whitelisted extensions (e.g. gif) fail
-            // createUri and cannot be saved to external storage — this hook falls back
-            // to getImageUri manually and writes into output array.
-            transaction.add(::installCreateUriHook.name) {
-                installCreateUriHook()
-            }
-            transaction.commit()
+        val transaction = HookTransaction(TAG)
+        // Force "save to album" button visible for emoji comments.
+        transaction.add(::installSaveEmojiToAlbumButtonHook.name) {
+            installSaveEmojiToAlbumButtonHook()
         }
+        // Before the save button's download callback fires, inject emoji URLs into
+        // comment.imageList[0].downloadUrl so the downloader picks them up.
+        // Without it: the downloader fetches nothing because imageList is empty.
+        transaction.add(::installClickSaveEmojiToAlbumButtonCallbackHook.name) {
+            installClickSaveEmojiToAlbumButtonCallbackHook()
+        }
+        // Intercept emoji download completion: detect real file type, convert video
+        // to GIF if needed, copy to album, show result toast, skip original handler
+        // — otherwise every downloaded emoji is saved as .png with MIME image/png.
+        transaction.add(::installEmojiDownloadedCallbackHook.name) {
+            installEmojiDownloadedCallbackHook()
+        }
+        // Fix MediaStore URI creation for converted GIF files: internal logic has a
+        // file-extension whitelist, so non-whitelisted extensions (e.g. gif) fail
+        // createUri and cannot be saved to external storage — this hook falls back
+        // to getImageUri manually and writes into output array.
+        transaction.add(::installCreateUriHook.name) {
+            installCreateUriHook()
+        }
+        transaction.commit()
     }
 
     private fun installSaveEmojiToAlbumButtonHook(): YukiMemberHookCreator.MemberHookCreator.Result? {

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/comment/CommentImageHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/comment/CommentImageHooker.kt
@@ -18,22 +18,20 @@ object CommentImageHooker : YukiBaseHooker() {
             return
         }
 
-        withProcess(mainProcessName) {
-            val packageInstance = DouyinPackage.instance
+        val packageInstance = DouyinPackage.instance
 
-            packageInstance.commentImageStruct.selfClass?.resolveMethod(packageInstance.commentImageStruct.getDownloadUrl())?.hook {
-                before {
-                    val originUrl =
-                        instance.getField<Any?>(packageInstance.commentImageStruct.originUrl())
-                    if (originUrl != null) {
-                        result = originUrl
-                    }
+        packageInstance.commentImageStruct.selfClass?.resolveMethod(packageInstance.commentImageStruct.getDownloadUrl())?.hook {
+            before {
+                val originUrl =
+                    instance.getField<Any?>(packageInstance.commentImageStruct.originUrl())
+                if (originUrl != null) {
+                    result = originUrl
                 }
-            } ?: run {
-                YLog.warn(
-                    "$TAG: Target method not found, watermark-free comment image download is not active"
-                )
             }
+        } ?: run {
+            YLog.warn(
+                "$TAG: Target method not found, watermark-free comment image download is not active"
+            )
         }
     }
 }

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/RecommendedFeedHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/RecommendedFeedHooker.kt
@@ -83,84 +83,82 @@ object RecommendedFeedHooker : YukiBaseHooker() {
 
         val packageInstance = DouyinPackage.instance
 
-        withProcess(mainProcessName) {
-            packageInstance.feedResponseHandler.selfClass?.resolveMethod(
-                packageInstance.feedResponseHandler.processAwemeList()
-            )?.hook {
-                before {
-                    val awemeList = args[2] as? MutableList<*> ?: return@before
+        packageInstance.feedResponseHandler.selfClass?.resolveMethod(
+            packageInstance.feedResponseHandler.processAwemeList()
+        )?.hook {
+            before {
+                val awemeList = args[2] as? MutableList<*> ?: return@before
 
-                    val iter = awemeList.iterator()
-                    while (iter.hasNext()) {
-                        val awemeObj = iter.next() ?: continue
+                val iter = awemeList.iterator()
+                while (iter.hasNext()) {
+                    val awemeObj = iter.next() ?: continue
 
-                        if (blockAdEnabled && awemeObj.invokeMethod<Boolean?>(packageInstance.aweme.getAd()) == true) {
-                            YLog.debug("$TAG: filtered by ad")
-                            iter.remove()
-                            continue
-                        } else if (blockEcomEnabled && awemeObj.invokeMethod<Boolean?>(packageInstance.aweme.isEcomAweme()) == true) {
-                            // NOTE: this filter logic has not been rigorously verified
-                            YLog.debug("$TAG: filtered by ecom aweme")
-                            iter.remove()
-                            continue
-                        } else if (blockGrouponLargeCardEnabled && awemeObj.getField<Any?>(
-                                packageInstance.aweme.grouponLargeCard()
-                            ) != null
-                        ) {
-                            // NOTE: this filter logic has not been rigorously verified
-                            YLog.debug("$TAG: filtered by groupon large card")
-                            iter.remove()
-                            continue
-                        } else if (blockLiveEnabled && awemeObj.invokeMethod<Boolean?>(packageInstance.aweme.isLive()) == true) {
-                            // NOTE: this filter logic has not been rigorously verified
-                            YLog.debug("$TAG: filtered by live")
-                            iter.remove()
-                            continue
-                        } else if (blockMultiImageEnabled &&
-                            awemeObj.invokeMethod<Boolean?>(packageInstance.aweme.isMultiImage()) == true
-                        ) {
-                            // NOTE: this filter logic has not been rigorously verified
-                            YLog.debug("$TAG: filtered by multi image")
-                            iter.remove()
-                            continue
-                        } else if (run {
-                                if (hideShortDurationLimit > hideLongDurationLimit) {
-                                    return@run false
-                                }
-
-                                if (awemeObj.invokeMethod<Boolean?>(
-                                        packageInstance.aweme.isNormalVideo()
-                                    ) == false
-                                ) {
-                                    return@run false
-                                }
-
-                                val duration = awemeObj.getField<Int?>(
-                                    packageInstance.aweme.duration()
-                                ) ?: return@run false
-
-                                return@run duration != 0 && (duration !in hideShortDurationLimit..hideLongDurationLimit)
+                    if (blockAdEnabled && awemeObj.invokeMethod<Boolean?>(packageInstance.aweme.getAd()) == true) {
+                        YLog.debug("$TAG: filtered by ad")
+                        iter.remove()
+                        continue
+                    } else if (blockEcomEnabled && awemeObj.invokeMethod<Boolean?>(packageInstance.aweme.isEcomAweme()) == true) {
+                        // NOTE: this filter logic has not been rigorously verified
+                        YLog.debug("$TAG: filtered by ecom aweme")
+                        iter.remove()
+                        continue
+                    } else if (blockGrouponLargeCardEnabled && awemeObj.getField<Any?>(
+                            packageInstance.aweme.grouponLargeCard()
+                        ) != null
+                    ) {
+                        // NOTE: this filter logic has not been rigorously verified
+                        YLog.debug("$TAG: filtered by groupon large card")
+                        iter.remove()
+                        continue
+                    } else if (blockLiveEnabled && awemeObj.invokeMethod<Boolean?>(packageInstance.aweme.isLive()) == true) {
+                        // NOTE: this filter logic has not been rigorously verified
+                        YLog.debug("$TAG: filtered by live")
+                        iter.remove()
+                        continue
+                    } else if (blockMultiImageEnabled &&
+                        awemeObj.invokeMethod<Boolean?>(packageInstance.aweme.isMultiImage()) == true
+                    ) {
+                        // NOTE: this filter logic has not been rigorously verified
+                        YLog.debug("$TAG: filtered by multi image")
+                        iter.remove()
+                        continue
+                    } else if (run {
+                            if (hideShortDurationLimit > hideLongDurationLimit) {
+                                return@run false
                             }
-                        ) {
-                            YLog.debug("$TAG: filtered by duration")
-                            iter.remove()
-                            continue
-                        } else if (isContainsBlockKwd(awemeObj)) {
-                            iter.remove()
-                            continue
+
+                            if (awemeObj.invokeMethod<Boolean?>(
+                                    packageInstance.aweme.isNormalVideo()
+                                ) == false
+                            ) {
+                                return@run false
+                            }
+
+                            val duration = awemeObj.getField<Int?>(
+                                packageInstance.aweme.duration()
+                            ) ?: return@run false
+
+                            return@run duration != 0 && (duration !in hideShortDurationLimit..hideLongDurationLimit)
                         }
+                    ) {
+                        YLog.debug("$TAG: filtered by duration")
+                        iter.remove()
+                        continue
+                    } else if (isContainsBlockKwd(awemeObj)) {
+                        iter.remove()
+                        continue
                     }
                 }
-            }?.result {
-                onConductFailure { param, throwable ->
-                    YLog.error("$TAG: Feed hook runtime error", throwable)
-                }
-                onHookingFailure { throwable ->
-                    YLog.error("$TAG: Failed to hook feed method", throwable)
-                }
-                onHooked {
-                    YLog.info("$TAG: Feed hook installed")
-                }
+            }
+        }?.result {
+            onConductFailure { param, throwable ->
+                YLog.error("$TAG: Feed hook runtime error", throwable)
+            }
+            onHookingFailure { throwable ->
+                YLog.error("$TAG: Failed to hook feed method", throwable)
+            }
+            onHooked {
+                YLog.info("$TAG: Feed hook installed")
             }
         }
     }

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/settings/SettingsHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/settings/SettingsHooker.kt
@@ -21,75 +21,73 @@ object SettingsHooker : YukiBaseHooker() {
     private val TAG = this::class.simpleName
 
     override fun onHook() {
-        withProcess(mainProcessName) {
-            val packageInstance = DouyinPackage.instance
+        val packageInstance = DouyinPackage.instance
 
-            packageInstance.douYinSettingNewVersionActivity.selfClass?.resolveMethod(
-                packageInstance.douYinSettingNewVersionActivity.onResume()
-            )?.hook {
-                after {
-                    val moduleSettingsTag = "dyenhancer_settings"
+        packageInstance.douYinSettingNewVersionActivity.selfClass?.resolveMethod(
+            packageInstance.douYinSettingNewVersionActivity.onResume()
+        )?.hook {
+            after {
+                val moduleSettingsTag = "dyenhancer_settings"
 
-                    val activity = instance as? Activity ?: return@after
+                val activity = instance as? Activity ?: return@after
 
-                    val settingsScrollView = instance.getField<ViewGroup?>(
-                        packageInstance.douYinSettingNewVersionActivity.settingsScrollView()
-                    ) ?: run {
-                        YLog.error("$TAG: Settings scroll view field not found, cannot inject module entry")
-                        return@after
-                    }
-
-                    if (settingsScrollView.findViewWithTag<View>(moduleSettingsTag) != null) {
-                        YLog.debug("$TAG: Module settings entry already injected, skipping")
-                        return@after
-                    }
-
-                    val moduleSettingsCommonItemView =
-                        packageInstance.commonItemView.selfClass?.getConstructor(Context::class.java)
-                            ?.newInstance(instance) as? ViewGroup
-                    if (moduleSettingsCommonItemView == null) {
-                        YLog.error("$TAG: Failed to create module settings entry")
-                        return@after
-                    }
-
-                    moduleSettingsCommonItemView.tag = moduleSettingsTag
-                    moduleSettingsCommonItemView.id = View.generateViewId()
-
-                    // Ensure the host app can find the module settings icon
-                    activity.injectModuleAppResources()
-                    moduleSettingsCommonItemView.invokeMethod<Unit>(
-                        packageInstance.commonItemView.setLeftTextAndIcon(),
-                        moduleAppResources.getString(R.string.app_name),
-                        R.drawable.ic_module_settings
-                    )
-                    moduleSettingsCommonItemView.invokeMethod<Unit>(
-                        packageInstance.commonItemView.setRightUIMode(),
-                        0 // arrow mode for the right UI element
-                    )
-                    moduleSettingsCommonItemView.layoutParams = LinearLayout.LayoutParams(
-                        ViewGroup.LayoutParams.MATCH_PARENT,
-                        ViewGroup.LayoutParams.WRAP_CONTENT
-                    )
-
-                    moduleSettingsCommonItemView.setOnClickListener {
-                        SettingsDialog.show(activity)
-                    }
-
-                    // Prefer inserting above the logout button; fallback to direct insert
-                    val targetParent = settingsScrollView
-                        .findViewWithTag<View?>("logout")
-                        ?.parent as? ViewGroup
-                        ?: (settingsScrollView.getChildAt(0) as? ViewGroup)
-                        ?: run {
-                            YLog.error("$TAG: Unable to find a suitable parent for module settings entry")
-                            return@after
-                        }
-
-                    targetParent.addView(
-                        moduleSettingsCommonItemView,
-                        0
-                    )
+                val settingsScrollView = instance.getField<ViewGroup?>(
+                    packageInstance.douYinSettingNewVersionActivity.settingsScrollView()
+                ) ?: run {
+                    YLog.error("$TAG: Settings scroll view field not found, cannot inject module entry")
+                    return@after
                 }
+
+                if (settingsScrollView.findViewWithTag<View>(moduleSettingsTag) != null) {
+                    YLog.debug("$TAG: Module settings entry already injected, skipping")
+                    return@after
+                }
+
+                val moduleSettingsCommonItemView =
+                    packageInstance.commonItemView.selfClass?.getConstructor(Context::class.java)
+                        ?.newInstance(instance) as? ViewGroup
+                if (moduleSettingsCommonItemView == null) {
+                    YLog.error("$TAG: Failed to create module settings entry")
+                    return@after
+                }
+
+                moduleSettingsCommonItemView.tag = moduleSettingsTag
+                moduleSettingsCommonItemView.id = View.generateViewId()
+
+                // Ensure the host app can find the module settings icon
+                activity.injectModuleAppResources()
+                moduleSettingsCommonItemView.invokeMethod<Unit>(
+                    packageInstance.commonItemView.setLeftTextAndIcon(),
+                    moduleAppResources.getString(R.string.app_name),
+                    R.drawable.ic_module_settings
+                )
+                moduleSettingsCommonItemView.invokeMethod<Unit>(
+                    packageInstance.commonItemView.setRightUIMode(),
+                    0 // arrow mode for the right UI element
+                )
+                moduleSettingsCommonItemView.layoutParams = LinearLayout.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT
+                )
+
+                moduleSettingsCommonItemView.setOnClickListener {
+                    SettingsDialog.show(activity)
+                }
+
+                // Prefer inserting above the logout button; fallback to direct insert
+                val targetParent = settingsScrollView
+                    .findViewWithTag<View?>("logout")
+                    ?.parent as? ViewGroup
+                    ?: (settingsScrollView.getChildAt(0) as? ViewGroup)
+                    ?: run {
+                        YLog.error("$TAG: Unable to find a suitable parent for module settings entry")
+                        return@after
+                    }
+
+                targetParent.addView(
+                    moduleSettingsCommonItemView,
+                    0
+                )
             }
         }
     }


### PR DESCRIPTION
`HookEntry` already scopes all hooks to `mainProcessName`, so the `withProcess(mainProcessName)` wrapping inside each sub-hooker's `onHook()` is redundant. Removed them and de-indented the inner logic
