### PR TITLE
refactor: correct misnamed CommentImageSaveHelper proto

### DIFF
--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/DouyinPackage.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/DouyinPackage.kt
@@ -83,7 +83,7 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
     val saveImageActionItem = SaveImageActionItemModule()
     val commentExtensionsKt = CommentExtensionsKtModule()
     val listenerProviderParam = ListenerProviderParamModule()
-    val commentImageSaveHelper = CommentImageSaveHelperModule()
+    val commentImageSaveDownloadListener = CommentImageSaveDownloadListenerModule()
     val downloadInfo = DownloadInfoModule()
     val digestUtils = DigestUtilsModule()
     val ugFileUtils = UGFileUtilsKtModule()
@@ -231,23 +231,23 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
         fun cert() = Field(hookInfo.listenerProviderParam.cert.nameOrNull)
     }
 
-    inner class CommentImageSaveHelperModule {
+    inner class CommentImageSaveDownloadListenerModule {
         val selfClass by weak {
-            hookInfo.commentImageSaveHelper.class_.nameOrNull
+            hookInfo.commentImageSaveDownloadListener.class_.nameOrNull
                 ?.toClass(classLoader)
         }
 
         fun onSuccessed() = Method(
-            hookInfo.commentImageSaveHelper.onSuccessed.nameOrNull,
-            hookInfo.commentImageSaveHelper.onSuccessed.parameters.valuesListOrNull
+            hookInfo.commentImageSaveDownloadListener.onSuccessed.nameOrNull,
+            hookInfo.commentImageSaveDownloadListener.onSuccessed.parameters.valuesListOrNull
         )
 
         fun notifyResult() = Method(
-            hookInfo.commentImageSaveHelper.notifyResult.nameOrNull,
-            hookInfo.commentImageSaveHelper.notifyResult.parameters.valuesListOrNull
+            hookInfo.commentImageSaveDownloadListener.notifyResult.nameOrNull,
+            hookInfo.commentImageSaveDownloadListener.notifyResult.parameters.valuesListOrNull
         )
 
-        fun listenerProviderParam() = Field(hookInfo.commentImageSaveHelper.listenerProviderParam.nameOrNull)
+        fun listenerProviderParam() = Field(hookInfo.commentImageSaveDownloadListener.listenerProviderParam.nameOrNull)
     }
 
     inner class DownloadInfoModule {
@@ -1034,8 +1034,8 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
                     }
                 }
 
-                commentImageSaveHelper =
-                    commentImageSaveHelper {
+                commentImageSaveDownloadListener =
+                    commentImageSaveDownloadListener {
                         runCatching {
                             val onSuccessedMethodData = bridge
                                 .findMethod {
@@ -1076,7 +1076,7 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
                                 YLog.error(
                                     "$TAG: Unable to populate ${this::class.java.enclosingClass?.simpleName} config, possibly due to unfound obfuscated methods"
                                 )
-                                return@commentImageSaveHelper
+                                return@commentImageSaveDownloadListener
                             }
 
                             class_ =
@@ -1106,7 +1106,7 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
                             listenerProviderParam = field {
                                 name = listenerProviderParamFieldName
                             }
-                            return@commentImageSaveHelper
+                            return@commentImageSaveDownloadListener
                         }.onFailure {
                             YLog.error("$TAG: Unable to populate config", it)
                         }

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/comment/CommentAudioHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/comment/CommentAudioHooker.kt
@@ -204,8 +204,8 @@ object CommentAudioHooker : YukiBaseHooker() {
     private fun installSaveDownloadedAudioHook(): YukiMemberHookCreator.MemberHookCreator.Result? {
         val packageInstance = DouyinPackage.instance
 
-        return packageInstance.commentImageSaveHelper.selfClass?.resolveMethod(
-            packageInstance.commentImageSaveHelper.onSuccessed()
+        return packageInstance.commentImageSaveDownloadListener.selfClass?.resolveMethod(
+            packageInstance.commentImageSaveDownloadListener.onSuccessed()
         )?.hook {
             before {
                 val downloadInfo = args[0] ?: return@before
@@ -230,7 +230,7 @@ object CommentAudioHooker : YukiBaseHooker() {
                 }.${ftypeInfo.extensions.first()}"
 
                 val context = instance.getField<Any>(
-                    packageInstance.commentImageSaveHelper.listenerProviderParam()
+                    packageInstance.commentImageSaveDownloadListener.listenerProviderParam()
                 )?.getField<Context>(
                     packageInstance.listenerProviderParam.context()
                 ) ?: run {
@@ -245,7 +245,7 @@ object CommentAudioHooker : YukiBaseHooker() {
                     ftypeInfo.mimeType,
                     "Music/douyin/audio",
                     instance.getField<Any>(
-                        packageInstance.commentImageSaveHelper.listenerProviderParam()
+                        packageInstance.commentImageSaveDownloadListener.listenerProviderParam()
                     )?.getField<Any>(
                         packageInstance.listenerProviderParam.cert()
                     )
@@ -270,7 +270,7 @@ object CommentAudioHooker : YukiBaseHooker() {
                 }.getOrDefault(false)
 
                 instance.invokeMethod<Any?>(
-                    packageInstance.commentImageSaveHelper.notifyResult(),
+                    packageInstance.commentImageSaveDownloadListener.notifyResult(),
                     context,
                     copyState
                 )

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/comment/CommentEmojiHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/comment/CommentEmojiHooker.kt
@@ -183,8 +183,8 @@ object CommentEmojiHooker : YukiBaseHooker() {
 
         val packageInstance = DouyinPackage.instance
 
-        packageInstance.commentImageSaveHelper.selfClass
-            ?.resolveMethod(packageInstance.commentImageSaveHelper.onSuccessed())?.hook {
+        packageInstance.commentImageSaveDownloadListener.selfClass
+            ?.resolveMethod(packageInstance.commentImageSaveDownloadListener.onSuccessed())?.hook {
                 before {
                     val downloadInfo = args[0] ?: return@before
 
@@ -284,7 +284,7 @@ object CommentEmojiHooker : YukiBaseHooker() {
                             }?.get<Context?>()
 
                     instance.invokeMethod<Any?>(
-                        DouyinPackage.instance.commentImageSaveHelper.notifyResult(),
+                        DouyinPackage.instance.commentImageSaveDownloadListener.notifyResult(),
                         context,
                         cpRet
                     )

--- a/app/src/main/proto/io/github/twyora/douyinenhancer/hook/configs.proto
+++ b/app/src/main/proto/io/github/twyora/douyinenhancer/hook/configs.proto
@@ -114,7 +114,7 @@ message ListenerProviderParam {
   optional Field cert = 3;
 }
 
-message CommentImageSaveHelper {
+message CommentImageSaveDownloadListener {
   optional Class class = 1;
   optional Method on_successed = 2;
   optional Method notify_result = 3;
@@ -216,7 +216,7 @@ message HookInfo {
   optional CommentLongPressItemModel comment_long_press_item_model = 11;
   optional SaveImageActionItem save_image_action_item = 12;
   optional CommentExtensionKt comment_extension_kt = 13;
-  optional CommentImageSaveHelper comment_image_save_helper = 14;
+  optional CommentImageSaveDownloadListener comment_image_save_download_listener = 14;
   optional DownloadInfo download_info = 15;
   optional DigestUtils digest_utils = 16;
   optional UGFileUtilsKt ug_file_utils = 17;


### PR DESCRIPTION
## Summary

Rename `CommentImageSaveHelper` to `CommentImageSaveDownloadListener` across proto definitions, module wiring, and all call sites.

## Motivation

The original name `CommentImageSaveHelper` is misleading — this proto message models a download listener
(with `on_successed`, `notify_result`, and `listener_provider_param`), not a generic helper/utility class.

## Why this is safe

The hook config cache (proto binary) is invalidated on every module/host app version bump:

- `moduleVersionCode` / `moduleVersionName` must match current build
- `hostVersionCode` must match installed host app
- `lastUpdateTime` must be newer than both module and host timestamp

So the persisted config is always regenerated from reflection after an update. While proto message/field renames would normally be breaking for deserialization of existing binary caches, in this project they have minimal blast radius — the old cache simply gets discarded and rebuilt.
