### PR TITLE
fix: correct misnamed settings category and filter description

### DIFF
--- a/app/src/main/res/values-zh-rCN/values-zh.xml
+++ b/app/src/main/res/values-zh-rCN/values-zh.xml
@@ -6,7 +6,7 @@
     <string name="settings_dialog_back">返回</string>
     <string name="settings_dialog_confirm_and_restart">确定并重启客户端</string>
     <string name="pref_category_save">保存</string>
-    <string name="pref_category_recommend">推荐</string>
+    <string name="pref_category_feed">内容</string>
     <string name="pref_category_misc">杂项</string>
     <string name="pref_misc_enable_hidden_features_title">✦ 启用隐藏功能</string>
     <string name="pref_misc_enable_hidden_features_summary">打开后可以使用隐藏功能</string>
@@ -57,7 +57,7 @@
     <string name="recommended_feed_filter_group_title">标题</string>
     <string name="recommended_feed_filter_group_uid">UID</string>
     <string name="recommended_feed_filter_group_author_nickname">作者昵称</string>
-    <string name="recommended_feed_filter_group_desc">视频文案</string>
+    <string name="recommended_feed_filter_group_desc">内容文案</string>
 
     <string name="add">添加</string>
     <string name="delete">删除</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,7 +6,7 @@
     <string name="settings_dialog_confirm_and_restart">Confirm &amp; Restart</string>
 
     <string name="pref_category_save">Save</string>
-    <string name="pref_category_recommend">Recommend</string>
+    <string name="pref_category_feed">Feed</string>
     <string name="pref_category_misc">Misc</string>
     <string name="pref_misc_enable_hidden_features_title">✦ Enable hidden features</string>
     <string name="pref_misc_enable_hidden_features_summary">Enable to use hidden features</string>

--- a/app/src/main/res/xml/prefs_setting.xml
+++ b/app/src/main/res/xml/prefs_setting.xml
@@ -37,7 +37,7 @@
     </PreferenceCategory>
 
     <PreferenceCategory
-        android:title="@string/pref_category_recommend">
+        android:title="@string/pref_category_feed">
         <Preference
             android:key="recommend_feed_filter"
             android:title="@string/recommended_feed_filter_dialog_title"/>


### PR DESCRIPTION
- Rename settings category: all options under this category operate on feed content itself, not recommendations
- Fix filter desc: the filter applies to all feed content, not just video