### PR TITLE
fix: image save failure in multi-image feeds

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -170,6 +170,7 @@ dependencies {
     implementation(libs.fastkv)
     implementation(libs.protobuf.javalite)
     implementation(libs.protobuf.kotlin.lite)
+    implementation(libs.commons.collections4)
 
     // ---------------------- HOOK ----------------------
     // 基础依赖

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/DouyinPackage.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/DouyinPackage.kt
@@ -589,6 +589,12 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
             hookInfo.video.getPlayAddr.nameOrNull,
             hookInfo.video.getPlayAddr.parameters.valuesListOrNull
         )
+
+        fun hasSuffixWaterMark() = Field(hookInfo.video.hasSuffixWaterMark.nameOrNull)
+
+        fun hasWaterMark() = Field(hookInfo.video.hasWaterMark.nameOrNull)
+
+        fun downloadAddr() = Field(hookInfo.video.downloadAddr.nameOrNull)
     }
 
     inner class ImageUrlStructModule {
@@ -607,6 +613,10 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
 
         fun downloadUrlList() = Field(
             hookInfo.imageUrlStruct.downloadUrlList.nameOrNull
+        )
+
+        fun video() = Field(
+            hookInfo.imageUrlStruct.video.nameOrNull
         )
     }
 
@@ -1608,9 +1618,6 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
                     grouponLargeCard = field {
                         name = "grouponLargeCard"
                     }
-                    isLivePhoto = field {
-                        name = "isLivePhoto"
-                    }
                     isLive = method {
                         name = "isLive"
                     }
@@ -1923,6 +1930,15 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
                                 values.addAll(getPlayAddrMethodData.paramTypeNames)
                             }
                         }
+                        hasSuffixWaterMark = field {
+                            name = "hasSuffixWaterMark"
+                        }
+                        hasWaterMark = field {
+                            name = "hasWaterMark"
+                        }
+                        downloadAddr = field {
+                            name = "downloadAddr"
+                        }
                     }.onFailure {
                         YLog.error("$TAG: Unable to populate config", it)
                     }
@@ -2122,6 +2138,9 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
                     }
                     downloadUrlList = field {
                         name = "downloadUrlList"
+                    }
+                    video = field {
+                        name = "video"
                     }
                 }
 

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/DouyinPackage.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/DouyinPackage.kt
@@ -85,6 +85,7 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
     val commentExtensionsKt = CommentExtensionsKtModule()
     val listenerProviderParam = ListenerProviderParamModule()
     val commentImageSaveDownloadListener = CommentImageSaveDownloadListenerModule()
+    val imageResourceRxDownloadListener = ImageResourceRxDownloadListenerModule()
     val downloadInfo = DownloadInfoModule()
     val digestUtils = DigestUtilsModule()
     val ugFileUtils = UGFileUtilsKtModule()
@@ -251,6 +252,20 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
         )
 
         fun listenerProviderParam() = Field(hookInfo.commentImageSaveDownloadListener.listenerProviderParam.nameOrNull)
+    }
+
+    inner class ImageResourceRxDownloadListenerModule {
+        val selfClass by weak {
+            hookInfo.imageResourceRxDownloadListener.class_.nameOrNull
+                ?.toClass(classLoader)
+        }
+
+        fun onSuccessed() = Method(
+            hookInfo.imageResourceRxDownloadListener.onSuccessed.nameOrNull,
+            hookInfo.imageResourceRxDownloadListener.onSuccessed.parameters.valuesListOrNull
+        )
+
+        fun observableEmitter() = Field(hookInfo.imageResourceRxDownloadListener.observableEmitter.nameOrNull)
     }
 
     inner class DownloadInfoModule {
@@ -448,6 +463,11 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
         fun images() = Field(hookInfo.aweme.images.nameOrNull)
 
         fun statistics() = Field(hookInfo.aweme.statistics.nameOrNull)
+
+        fun getAid() = Method(
+            hookInfo.aweme.getAid.nameOrNull,
+            hookInfo.aweme.getAid.parameters.valuesListOrNull
+        )
     }
 
     inner class AwemeStatisticsModule {
@@ -1504,6 +1524,9 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
                     statistics = field {
                         name = "statistics"
                     }
+                    getAid = method {
+                        name = "getAid"
+                    }
                 }
 
                 awemeStatistics = awemeStatistics {
@@ -1803,6 +1826,91 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
                                 getVisibilityMethod.parameterTypes.forEach { paramType ->
                                     values.add(paramType.name)
                                 }
+                            }
+                        }
+                    }.onFailure {
+                        YLog.error("$TAG: Unable to populate config", it)
+                    }
+                }
+
+                imageResourceRxDownloadListener = imageResourceRxDownloadListener {
+                    runCatching {
+                        val imageDownloadObservableSubscribeMethodData = bridge.findMethod {
+                            matcher {
+                                params {
+                                    add("io.reactivex.ObservableEmitter")
+                                }
+                                usingStrings {
+                                    add("image_music_resource_1")
+                                }
+                                invokeMethods {
+                                    add {
+                                        descriptor =
+                                            "Lcom/ss/android/socialbase/downloader/model/DownloadTask;->monitorScene(Ljava/lang/String;)Lcom/ss/android/socialbase/downloader/model/DownloadTask;"
+                                    }
+                                }
+                            }
+                        }.singleOrNull()
+                        if (imageDownloadObservableSubscribeMethodData == null) {
+                            YLog.error(
+                                "$TAG: Unable to populate ${this::class.java.enclosingClass?.simpleName} config, possibly due to unfound obfuscated methods"
+                            )
+                            return@imageResourceRxDownloadListener
+                        }
+
+                        val imgResRxDownloadListenerList = imageDownloadObservableSubscribeMethodData.invokes.filter {
+                            it.methodName == "<init>" && it.paramTypeNames.contains("io.reactivex.ObservableEmitter")
+                        }.map {
+                            it.className
+                        }.distinct()
+                        if (imgResRxDownloadListenerList.isEmpty() || imgResRxDownloadListenerList.size > 1) {
+                            if (imgResRxDownloadListenerList.isEmpty()) {
+                                YLog.error(
+                                    "$TAG: Unable to populate ${this::class.java.enclosingClass?.simpleName} config, image resource rx download listener not found"
+                                )
+                            } else {
+                                YLog.error(
+                                    "$TAG: Unable to populate ${this::class.java.enclosingClass?.simpleName} config, multiple image resource rx download listener candidates found, don't know which to pick"
+                                )
+                            }
+                            return@imageResourceRxDownloadListener
+                        }
+
+                        val imageResRxDownloadListenerName = imgResRxDownloadListenerList.first()
+                        val imageResRxDownloadListenerOnSuccessedMethod =
+                            imageResRxDownloadListenerName.toClass(hostAppClassLoader).resolve().optional().firstMethodOrNull {
+                                name = "onSuccessed"
+                                parameters(
+                                    "com.ss.android.socialbase.downloader.model.DownloadInfo"
+                                )
+                            }?.self
+                        val imageResRxDownloadListenerObservableEmitter =
+                            imageResRxDownloadListenerName.toClass(hostAppClassLoader).resolve().optional().firstFieldOrNull {
+                                type = "io.reactivex.ObservableEmitter"
+                            }?.self
+
+                        if (imageResRxDownloadListenerOnSuccessedMethod == null || imageResRxDownloadListenerObservableEmitter == null) {
+                            YLog.error(
+                                "$TAG: Unable to populate ${this::class.java.enclosingClass?.simpleName} config, possibly due to unfound obfuscated methods or fields"
+                            )
+                            return@imageResourceRxDownloadListener
+                        }
+
+                        class_ = class_ {
+                            name = imageResRxDownloadListenerName
+                        }
+                        observableEmitter = field {
+                            name = imageResRxDownloadListenerObservableEmitter.name
+                        }
+                        onSuccessed = method {
+                            name = imageResRxDownloadListenerOnSuccessedMethod.name
+                            parameters = MethodKt.parameters {
+                                values.clear()
+                                values.addAll(
+                                    imageResRxDownloadListenerOnSuccessedMethod.parameterTypes.map {
+                                        it.name
+                                    }
+                                )
                             }
                         }
                     }.onFailure {

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/DouyinPackage.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/DouyinPackage.kt
@@ -87,7 +87,6 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
     val commentExtensionsKt = CommentExtensionsKtModule()
     val listenerProviderParam = ListenerProviderParamModule()
     val commentImageSaveDownloadListener = CommentImageSaveDownloadListenerModule()
-    val imageResourceRxDownloadListener = ImageResourceRxDownloadListenerModule()
     val downloadInfo = DownloadInfoModule()
     val digestUtils = DigestUtilsModule()
     val ugFileUtils = UGFileUtilsKtModule()
@@ -261,20 +260,6 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
         )
 
         fun listenerProviderParam() = Field(hookInfo.commentImageSaveDownloadListener.listenerProviderParam.nameOrNull)
-    }
-
-    inner class ImageResourceRxDownloadListenerModule {
-        val selfClass by weak {
-            hookInfo.imageResourceRxDownloadListener.class_.nameOrNull
-                ?.toClass(classLoader)
-        }
-
-        fun onSuccessed() = Method(
-            hookInfo.imageResourceRxDownloadListener.onSuccessed.nameOrNull,
-            hookInfo.imageResourceRxDownloadListener.onSuccessed.parameters.valuesListOrNull
-        )
-
-        fun observableEmitter() = Field(hookInfo.imageResourceRxDownloadListener.observableEmitter.nameOrNull)
     }
 
     inner class DownloadInfoModule {
@@ -2188,91 +2173,6 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
                                 getVisibilityMethod.parameterTypes.forEach { paramType ->
                                     values.add(paramType.name)
                                 }
-                            }
-                        }
-                    }.onFailure {
-                        YLog.error("$TAG: Unable to populate config", it)
-                    }
-                }
-
-                imageResourceRxDownloadListener = imageResourceRxDownloadListener {
-                    runCatching {
-                        val imageDownloadObservableSubscribeMethodData = bridge.findMethod {
-                            matcher {
-                                params {
-                                    add("io.reactivex.ObservableEmitter")
-                                }
-                                usingStrings {
-                                    add("image_music_resource_1")
-                                }
-                                invokeMethods {
-                                    add {
-                                        descriptor =
-                                            "Lcom/ss/android/socialbase/downloader/model/DownloadTask;->monitorScene(Ljava/lang/String;)Lcom/ss/android/socialbase/downloader/model/DownloadTask;"
-                                    }
-                                }
-                            }
-                        }.singleOrNull()
-                        if (imageDownloadObservableSubscribeMethodData == null) {
-                            YLog.error(
-                                "$TAG: Unable to populate ${this::class.java.enclosingClass?.simpleName} config, possibly due to unfound obfuscated methods"
-                            )
-                            return@imageResourceRxDownloadListener
-                        }
-
-                        val imgResRxDownloadListenerList = imageDownloadObservableSubscribeMethodData.invokes.filter {
-                            it.methodName == "<init>" && it.paramTypeNames.contains("io.reactivex.ObservableEmitter")
-                        }.map {
-                            it.className
-                        }.distinct()
-                        if (imgResRxDownloadListenerList.isEmpty() || imgResRxDownloadListenerList.size > 1) {
-                            if (imgResRxDownloadListenerList.isEmpty()) {
-                                YLog.error(
-                                    "$TAG: Unable to populate ${this::class.java.enclosingClass?.simpleName} config, image resource rx download listener not found"
-                                )
-                            } else {
-                                YLog.error(
-                                    "$TAG: Unable to populate ${this::class.java.enclosingClass?.simpleName} config, multiple image resource rx download listener candidates found, don't know which to pick"
-                                )
-                            }
-                            return@imageResourceRxDownloadListener
-                        }
-
-                        val imageResRxDownloadListenerName = imgResRxDownloadListenerList.first()
-                        val imageResRxDownloadListenerOnSuccessedMethod =
-                            imageResRxDownloadListenerName.toClass(hostAppClassLoader).resolve().optional().firstMethodOrNull {
-                                name = "onSuccessed"
-                                parameters(
-                                    "com.ss.android.socialbase.downloader.model.DownloadInfo"
-                                )
-                            }?.self
-                        val imageResRxDownloadListenerObservableEmitter =
-                            imageResRxDownloadListenerName.toClass(hostAppClassLoader).resolve().optional().firstFieldOrNull {
-                                type = "io.reactivex.ObservableEmitter"
-                            }?.self
-
-                        if (imageResRxDownloadListenerOnSuccessedMethod == null || imageResRxDownloadListenerObservableEmitter == null) {
-                            YLog.error(
-                                "$TAG: Unable to populate ${this::class.java.enclosingClass?.simpleName} config, possibly due to unfound obfuscated methods or fields"
-                            )
-                            return@imageResourceRxDownloadListener
-                        }
-
-                        class_ = class_ {
-                            name = imageResRxDownloadListenerName
-                        }
-                        observableEmitter = field {
-                            name = imageResRxDownloadListenerObservableEmitter.name
-                        }
-                        onSuccessed = method {
-                            name = imageResRxDownloadListenerOnSuccessedMethod.name
-                            parameters = MethodKt.parameters {
-                                values.clear()
-                                values.addAll(
-                                    imageResRxDownloadListenerOnSuccessedMethod.parameterTypes.map {
-                                        it.name
-                                    }
-                                )
                             }
                         }
                     }.onFailure {

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/DouyinPackage.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/DouyinPackage.kt
@@ -103,6 +103,10 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
     val abTestServiceImpl = ABTestServiceImplModule()
     val lppDownloadModule = LppDownloadModuleModule()
     val awemeStatistics = AwemeStatisticsModule()
+    val heifDecoder = HeifDecoderModule()
+    val heifBitmapFactoryImpl = HeifBitmapFactoryImplModule()
+    val downLoadExecutor = DownLoadExecutorModule()
+    val downLoadTask = DownLoadTaskModule()
     val mainActivity = MainActivityModule()
 
     inner class CommentImageStructModule {
@@ -483,6 +487,48 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
         fun diggCount() = Field(hookInfo.awemeStatistics.diggCount.nameOrNull)
 
         fun shareCount() = Field(hookInfo.awemeStatistics.shareCount.nameOrNull)
+    }
+
+    inner class HeifDecoderModule {
+        val selfClass by weak {
+            hookInfo.heifDecoder.class_.nameOrNull
+                ?.toClass(classLoader)
+        }
+
+        fun sBitmapFactory() = Field(hookInfo.heifDecoder.sBitmapFactory.nameOrNull)
+    }
+
+    inner class HeifBitmapFactoryImplModule {
+        val selfClass by weak {
+            hookInfo.heifBitmapFactoryImpl.class_.nameOrNull
+                ?.toClass(classLoader)
+        }
+
+        fun decodeByteArray() = Method(
+            hookInfo.heifBitmapFactoryImpl.decodeByteArray.nameOrNull,
+            hookInfo.heifBitmapFactoryImpl.decodeByteArray.parameters.valuesListOrNull
+        )
+    }
+
+    inner class DownLoadExecutorModule {
+        val selfClass by weak {
+            hookInfo.downLoadExecutor.class_.nameOrNull
+                ?.toClass(classLoader)
+        }
+
+        fun execute() = Method(
+            hookInfo.downLoadExecutor.execute.nameOrNull,
+            hookInfo.downLoadExecutor.execute.parameters.valuesListOrNull
+        )
+    }
+
+    inner class DownLoadTaskModule {
+        val selfClass by weak {
+            hookInfo.downLoadTask.class_.nameOrNull
+                ?.toClass(classLoader)
+        }
+
+        fun targetFilePath() = Field(hookInfo.downLoadTask.targetFilePath.nameOrNull)
     }
 
     inner class VideoModule {
@@ -1544,6 +1590,100 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
                     }
                     shareCount = field {
                         name = "shareCount"
+                    }
+                }
+
+                heifDecoder = heifDecoder {
+                    class_ = class_ {
+                        name = "com.bytedance.fresco.heif.HeifDecoder"
+                    }
+                    sBitmapFactory = field {
+                        name = "sBitmapFactory"
+                    }
+                }
+
+                heifBitmapFactoryImpl = heifBitmapFactoryImpl {
+                    class_ = class_ {
+                        name = "com.bytedance.fresco.heif.HeifBitmapFactoryImpl"
+                    }
+                    decodeByteArray = method {
+                        name = "decodeByteArray"
+                        parameters = MethodKt.parameters {
+                            values.clear()
+                            values.addAll(
+                                listOf(
+                                    "[B",
+                                    "int",
+                                    "int",
+                                    "android.graphics.BitmapFactory\$Options"
+                                )
+                            )
+                        }
+                    }
+                }
+
+                downLoadExecutor = downLoadExecutor {
+                    runCatching {
+                        val executeMethodData = bridge.findMethod {
+                            matcher {
+                                modifiers = Modifier.PUBLIC or Modifier.FINAL
+                                returnType = "boolean"
+                                paramCount = 1
+                                usingStrings {
+                                    add("/douyin")
+                                    add("share_")
+                                    add(".png")
+                                    add("DownLoadExecutor")
+                                }
+                                invokeMethods {
+                                    add {
+                                        descriptor =
+                                            "Lcom/bytedance/android/ug/UGFileUtilsKt;->getExternalStorageDirectory(Ljava/lang/String;Z)Ljava/lang/String;"
+                                    }
+                                }
+                            }
+                        }.singleOrNull() ?: run {
+                            YLog.error(
+                                "$TAG: Unable to populate ${this::class.java.enclosingClass?.simpleName} config, possibly due to unfound obfuscated methods"
+                            )
+                            return@downLoadExecutor
+                        }
+
+                        class_ = class_ {
+                            name = executeMethodData.className
+                        }
+                        execute = method {
+                            name = executeMethodData.methodName
+                            parameters = MethodKt.parameters {
+                                values.clear()
+                                values.addAll(executeMethodData.paramTypeNames)
+                            }
+                        }
+                    }.onFailure {
+                        YLog.error("$TAG: Unable to populate config", it)
+                    }
+                }
+
+                downLoadTask = downLoadTask {
+                    runCatching {
+                        val downloadTaskClassName = this@hookInfo.downLoadExecutor.execute.parameters.valuesListOrNull?.firstOrNull()
+                        val targetFilePathField = downloadTaskClassName?.toClass(hostAppClassLoader)?.resolve()?.firstFieldOrNull {
+                            type = String::class
+                        }?.self ?: run {
+                            YLog.error(
+                                "$TAG: Unable to populate ${this::class.java.enclosingClass?.simpleName} config, possibly due to unfound obfuscated fields"
+                            )
+                            return@downLoadTask
+                        }
+
+                        class_ = class_ {
+                            name = downloadTaskClassName
+                        }
+                        targetFilePath = field {
+                            name = targetFilePathField.name
+                        }
+                    }.onFailure {
+                        YLog.error("$TAG: Unable to populate config", it)
                     }
                 }
 

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/DouyinPackage.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/DouyinPackage.kt
@@ -109,6 +109,7 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
     val heifBitmapFactoryImpl = HeifBitmapFactoryImplModule()
     val downLoadExecutor = DownLoadExecutorModule()
     val downLoadTask = DownLoadTaskModule()
+    val downloadLivePhotoExecutor = DownloadLivePhotoExecutorModule()
     val singleImageToMp4Composer = SingleImageToMp4ComposerModule()
     val multiImageToMp4Composer = MultiImageToMp4ComposerModule()
     val mainActivity = MainActivityModule()
@@ -532,7 +533,22 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
                 ?.toClass(classLoader)
         }
 
-        fun targetFilePath() = Field(hookInfo.downLoadTask.targetFilePath.nameOrNull)
+        fun getTargetFilePaths() = Method(
+            hookInfo.downLoadTask.getTargetFilePaths.nameOrNull,
+            hookInfo.downLoadTask.getTargetFilePaths.parameters.valuesListOrNull
+        )
+    }
+
+    inner class DownloadLivePhotoExecutorModule {
+        val selfClass by weak {
+            hookInfo.downloadLivePhotoExecutor.class_.nameOrNull
+                ?.toClass(classLoader)
+        }
+
+        fun encodeLivePhoto() = Method(
+            hookInfo.downloadLivePhotoExecutor.encodeLivePhoto.nameOrNull,
+            hookInfo.downloadLivePhotoExecutor.encodeLivePhoto.parameters.valuesListOrNull
+        )
     }
 
     inner class SingleImageToMp4ComposerModule {
@@ -653,6 +669,11 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
         fun enableSaveImageToVideoLocalWaterMask() = Method(
             hookInfo.abTestServiceImpl.enableSaveImageToVideoLocalWaterMask.nameOrNull,
             hookInfo.abTestServiceImpl.enableSaveImageToVideoLocalWaterMask.parameters.valuesListOrNull
+        )
+
+        fun enableVEAddLiveVideoWaterMark() = Method(
+            hookInfo.abTestServiceImpl.enableVEAddLiveVideoWaterMark.nameOrNull,
+            hookInfo.abTestServiceImpl.enableVEAddLiveVideoWaterMark.parameters.valuesListOrNull
         )
     }
 
@@ -1587,6 +1608,9 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
                     grouponLargeCard = field {
                         name = "grouponLargeCard"
                     }
+                    isLivePhoto = field {
+                        name = "isLivePhoto"
+                    }
                     isLive = method {
                         name = "isLive"
                     }
@@ -1699,11 +1723,22 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
                 downLoadTask = downLoadTask {
                     runCatching {
                         val downloadTaskClassName = this@hookInfo.downLoadExecutor.execute.parameters.valuesListOrNull?.firstOrNull()
-                        val targetFilePathField = downloadTaskClassName?.toClass(hostAppClassLoader)?.resolve()?.firstFieldOrNull {
-                            type = String::class
-                        }?.self ?: run {
+                            ?: run {
+                                YLog.error(
+                                    "$TAG: Unable to populate ${this::class.java.enclosingClass?.simpleName} config, possibly due to unfound obfuscated classes"
+                                )
+                                return@downLoadTask
+                            }
+                        val getTargetFilePathsMethodData = bridge.findMethod {
+                            matcher {
+                                declaredClass = downloadTaskClassName
+                                returnType = "java.util.List"
+                            }
+                        }.singleOrNull()
+
+                        if (getTargetFilePathsMethodData == null) {
                             YLog.error(
-                                "$TAG: Unable to populate ${this::class.java.enclosingClass?.simpleName} config, possibly due to unfound obfuscated fields"
+                                "$TAG: Unable to populate ${this::class.java.enclosingClass?.simpleName} config, possibly due to unfound obfuscated methods"
                             )
                             return@downLoadTask
                         }
@@ -1711,8 +1746,45 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
                         class_ = class_ {
                             name = downloadTaskClassName
                         }
-                        targetFilePath = field {
-                            name = targetFilePathField.name
+                        getTargetFilePaths = method {
+                            name = getTargetFilePathsMethodData.methodName
+                            parameters = MethodKt.parameters {
+                                values.clear()
+                                values.addAll(getTargetFilePathsMethodData.paramTypeNames)
+                            }
+                        }
+                    }.onFailure {
+                        YLog.error("$TAG: Unable to populate config", it)
+                    }
+                }
+
+                downloadLivePhotoExecutor = downloadLivePhotoExecutor {
+                    runCatching {
+                        val encodeLivePhotoMethodData = bridge.findMethod {
+                            matcher {
+                                modifiers = Modifier.PUBLIC or Modifier.FINAL
+                                returnType = "boolean"
+                                usingStrings {
+                                    add("DownloadLiveExecutor")
+                                    add("encode live photo isFinish: ")
+                                }
+                            }
+                        }.singleOrNull() ?: run {
+                            YLog.error(
+                                "$TAG: Unable to populate ${this::class.java.enclosingClass?.simpleName} config, possibly due to unfound obfuscated methods"
+                            )
+                            return@downloadLivePhotoExecutor
+                        }
+
+                        class_ = class_ {
+                            name = encodeLivePhotoMethodData.className
+                        }
+                        encodeLivePhoto = method {
+                            name = encodeLivePhotoMethodData.methodName
+                            parameters = MethodKt.parameters {
+                                values.clear()
+                                values.addAll(encodeLivePhotoMethodData.paramTypeNames)
+                            }
                         }
                     }.onFailure {
                         YLog.error("$TAG: Unable to populate config", it)
@@ -2059,6 +2131,9 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
                     }
                     enableSaveImageToVideoLocalWaterMask = method {
                         name = "enableSaveImageToVideoLocalWaterMask"
+                    }
+                    enableVEAddLiveVideoWaterMark = method {
+                        name = "enableVEAddLiveVideoWaterMark"
                     }
                 }
 

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/DouyinPackage.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/DouyinPackage.kt
@@ -8,6 +8,8 @@ import android.app.AndroidAppHelper
 import android.content.Context
 import android.provider.Settings
 import com.highcapable.kavaref.KavaRef.Companion.resolve
+import com.highcapable.kavaref.condition.matcher.extension.parameterizedBy
+import com.highcapable.kavaref.condition.matcher.extension.toTypeMatcher
 import com.highcapable.kavaref.condition.type.Modifiers
 import com.highcapable.kavaref.extension.toClass
 import com.highcapable.kavaref.extension.toClassOrNull
@@ -107,6 +109,8 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
     val heifBitmapFactoryImpl = HeifBitmapFactoryImplModule()
     val downLoadExecutor = DownLoadExecutorModule()
     val downLoadTask = DownLoadTaskModule()
+    val singleImageToMp4Composer = SingleImageToMp4ComposerModule()
+    val multiImageToMp4Composer = MultiImageToMp4ComposerModule()
     val mainActivity = MainActivityModule()
 
     inner class CommentImageStructModule {
@@ -529,6 +533,34 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
         }
 
         fun targetFilePath() = Field(hookInfo.downLoadTask.targetFilePath.nameOrNull)
+    }
+
+    inner class SingleImageToMp4ComposerModule {
+        val selfClass by weak {
+            hookInfo.singleImageToMp4Composer.class_.nameOrNull
+                ?.toClass(classLoader)
+        }
+
+        fun onLoad() = Method(
+            hookInfo.singleImageToMp4Composer.onLoad.nameOrNull,
+            hookInfo.singleImageToMp4Composer.onLoad.parameters.valuesListOrNull
+        )
+    }
+
+    inner class MultiImageToMp4ComposerModule {
+        val selfClass by weak {
+            hookInfo.multiImageToMp4Composer.class_.nameOrNull
+                ?.toClass(classLoader)
+        }
+
+        fun onLoad() = Method(
+            hookInfo.multiImageToMp4Composer.onLoad.nameOrNull,
+            hookInfo.multiImageToMp4Composer.onLoad.parameters.valuesListOrNull
+        )
+
+        fun imagePathList() = Field(
+            hookInfo.multiImageToMp4Composer.imagePathList.nameOrNull
+        )
     }
 
     inner class VideoModule {
@@ -1681,6 +1713,102 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
                         }
                         targetFilePath = field {
                             name = targetFilePathField.name
+                        }
+                    }.onFailure {
+                        YLog.error("$TAG: Unable to populate config", it)
+                    }
+                }
+
+                singleImageToMp4Composer = singleImageToMp4Composer {
+                    runCatching {
+                        val onLoadMethodData = bridge.findMethod {
+                            matcher {
+                                name = "onLoad"
+                                usingStrings {
+                                    add("[onLoad] failed, cause path not exist")
+                                }
+                                invokeMethods {
+                                    add {
+                                        descriptor = "Lcom/ss/android/ugc/aweme/utils/FileUtils;->checkFileExists(Ljava/lang/String;)Z"
+                                    }
+                                    add {
+                                        descriptor =
+                                            "Lcom/ss/android/ugc/aweme/services/external/ui/IStoryService;->convertImgToMp4(Landroid/content/Context;Landroidx/lifecycle/LifecycleOwner;Ljava/lang/String;Ljava/lang/String;ZJLjava/lang/String;Lcom/ss/android/ugc/aweme/services/external/ui/IStoryService\$OnMuxImgToMp4Callback;)V"
+                                    }
+                                }
+                            }
+                        }.singleOrNull() ?: run {
+                            YLog.error(
+                                "$TAG: Unable to populate ${this::class.java.enclosingClass?.simpleName} config, possibly due to unfound obfuscated methods"
+                            )
+                            return@singleImageToMp4Composer
+                        }
+
+                        class_ = class_ {
+                            name = onLoadMethodData.className
+                        }
+                        onLoad = method {
+                            name = onLoadMethodData.methodName
+                            parameters = MethodKt.parameters {
+                                values.clear()
+                                values.addAll(onLoadMethodData.paramTypeNames)
+                            }
+                        }
+                    }.onFailure {
+                        YLog.error("$TAG: Unable to populate config", it)
+                    }
+                }
+
+                multiImageToMp4Composer = multiImageToMp4Composer {
+                    runCatching {
+                        val onLoadMethodData = bridge.findMethod {
+                            matcher {
+                                name = "onLoad"
+                                usingStrings {
+                                    add("images file not exist!")
+                                }
+                                invokeMethods {
+                                    add {
+                                        descriptor = "Lcom/ss/android/ugc/aweme/utils/FileUtils;->checkFileExists(Ljava/lang/String;)Z"
+                                    }
+                                    add {
+                                        descriptor =
+                                            "Lcom/ss/android/ugc/aweme/services/external/ui/IStoryService;->convertImgListToMp4UseMusicUrl(Landroid/app/Activity;Landroidx/lifecycle/LifecycleOwner;Ljava/util/List;Lcom/ss/android/ugc/aweme/music/model/Music;ZZLjava/lang/String;ZLkotlin/jvm/functions/Function1;)V"
+                                    }
+                                }
+                            }
+                        }.singleOrNull()
+
+                        val imagePathListFieldName = onLoadMethodData?.className
+                            ?.toClass(hostAppClassLoader)
+                            ?.resolve()
+                            ?.firstFieldOrNull {
+                                genericType = List::class.parameterizedBy(
+                                    List::class.parameterizedBy(
+                                        String::class.toTypeMatcher()
+                                    )
+                                )
+                            }?.self?.name
+
+                        if (onLoadMethodData == null || imagePathListFieldName == null) {
+                            YLog.error(
+                                "$TAG: Unable to populate ${this::class.java.enclosingClass?.simpleName} config, possibly due to unfound obfuscated methods or fields"
+                            )
+                            return@multiImageToMp4Composer
+                        }
+
+                        class_ = class_ {
+                            name = onLoadMethodData.className
+                        }
+                        onLoad = method {
+                            name = onLoadMethodData.methodName
+                            parameters = MethodKt.parameters {
+                                values.clear()
+                                values.addAll(onLoadMethodData.paramTypeNames)
+                            }
+                        }
+                        imagePathList = field {
+                            name = imagePathListFieldName
                         }
                     }.onFailure {
                         YLog.error("$TAG: Unable to populate config", it)

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/FeedMultiImageHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/FeedMultiImageHooker.kt
@@ -2,8 +2,6 @@ package io.github.twyora.douyinenhancer.hook.feed
 
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
-import android.icu.text.RelativeDateTimeFormatter
-import android.os.strictmode.UntaggedSocketViolation
 import com.highcapable.kavaref.KavaRef.Companion.resolve
 import com.highcapable.yukihookapi.hook.core.YukiMemberHookCreator
 import com.highcapable.yukihookapi.hook.entity.YukiBaseHooker
@@ -13,21 +11,25 @@ import io.github.twyora.douyinenhancer.config.key.SaveKey
 import io.github.twyora.douyinenhancer.hook.DouyinPackage
 import io.github.twyora.douyinenhancer.hook.HookOnMainProcess
 import io.github.twyora.douyinenhancer.utils.Field
+import io.github.twyora.douyinenhancer.utils.FileTypeDetector
 import io.github.twyora.douyinenhancer.utils.Method
 import io.github.twyora.douyinenhancer.utils.getField
 import io.github.twyora.douyinenhancer.utils.getStaticField
 import io.github.twyora.douyinenhancer.utils.invokeMethod
 import io.github.twyora.douyinenhancer.utils.resolveMethod
 import io.github.twyora.douyinenhancer.utils.setField
-import org.apache.commons.collections4.queue.CircularFifoQueue
+import java.io.File
 import java.io.FileInputStream
-import java.nio.file.Files
-import kotlin.io.path.Path
+import org.apache.commons.collections4.queue.CircularFifoQueue
 
 @HookOnMainProcess
 object FeedMultiImageHooker : YukiBaseHooker() {
     private val TAG = this::class.simpleName
+
     private val ring = CircularFifoQueue<String>(5)
+
+    private val packageInstance
+        get() = DouyinPackage.instance
 
     override fun onHook() {
         if (!FastKVConfigManager.settings.getBoolean(SaveKey.FEED_MULTI_IMAGE_REMOVE_WATERMARK, false)) {
@@ -37,7 +39,6 @@ object FeedMultiImageHooker : YukiBaseHooker() {
         installInjectPlayUrlIntoImageDownloadHook()
         installDisableSaveImageToVideoLocalWaterMaskHook()
 
-        val packageInstance = DouyinPackage.instance
         packageInstance.imageResourceRxDownloadListener.selfClass?.resolveMethod(
             packageInstance.imageResourceRxDownloadListener.onSuccessed()
         )?.hook {
@@ -55,51 +56,72 @@ object FeedMultiImageHooker : YukiBaseHooker() {
             }
         }
 
-        //LX/19xB;->LIZIZ(LX/19u9;)Z
-        "X.19xB".toClass().resolve().firstMethodOrNull {
-            name = "LIZIZ"
-        }?.hook {
+        packageInstance.downLoadExecutor.selfClass?.resolveMethod(
+            packageInstance.downLoadExecutor.execute()
+        )?.hook {
             before {
-                val _19u9 = args[0] ?: return@before
-                val imgFilePath = _19u9.getField<String>(
-                    Field(name = "LIZJ")
+                val downloadTask = args[0] ?: return@before
+
+                val imageFilePath = downloadTask.getField<String>(
+                    packageInstance.downLoadTask.targetFilePath()
                 )
-                if (imgFilePath == null) {
-                    YLog.error("$TAG: imgFilePath is null")
+                if (imageFilePath == null) {
+                    YLog.error("$TAG: Failed to get image file path from download task")
                     return@before
-                } else {
-                    YLog.debug("$TAG: imgFilePath: $imgFilePath")
                 }
 
-                val imgBytes = FileInputStream(imgFilePath).use {
+                val imageFile = File(imageFilePath)
+                if (!imageFile.exists()) {
+                    YLog.error("$TAG: Image file does not exist")
+                    return@before
+                }
+
+                val fvvicInfo = FileTypeDetector.detect(imageFile)
+                if (fvvicInfo.mimeType != "image/vvic") {
+                    YLog.debug("$TAG: Image is not in vvic format (got ${fvvicInfo.mimeType}), skipping")
+                    return@before
+                }
+
+                // convert to bitmap
+                val imageBytes = FileInputStream(imageFile).use {
                     it.readBytes()
                 }
-                val options = BitmapFactory.Options()
-                options.inPreferredConfig = Bitmap.Config.ARGB_8888
-
-                val bitmap = "com.bytedance.fresco.heif.HeifDecoder".toClass().getStaticField<Any>(
-                    Field(name = "sBitmapFactory")
+                val bitmap = packageInstance.heifDecoder.selfClass?.getStaticField<Any>(
+                    packageInstance.heifDecoder.sBitmapFactory()
                 )?.invokeMethod<Bitmap>(
-                    Method(name = "decodeByteArray", parameters = null),
-                    imgBytes,
+                    packageInstance.heifBitmapFactoryImpl.decodeByteArray(),
+                    imageBytes,
                     0,
-                    imgBytes.size,
-                    options
+                    imageBytes.size,
+                    BitmapFactory.Options().apply {
+                        inPreferredConfig = Bitmap.Config.ARGB_8888
+                    }
                 )
                 if (bitmap == null) {
-                    YLog.error("$TAG: bitmap is null")
+                    YLog.error("$TAG: Failed to decode image to bitmap")
                     return@before
-                } else {
-                    YLog.info("$TAG: bitmap nooooooooooot null!")
                 }
+
+                // save bitmap as png alongside the original file
+                val pngFile = File(imageFilePath).run { resolveSibling("$nameWithoutExtension.png") }
+                runCatching {
+                    pngFile.outputStream().use { out ->
+                        require(bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)) {
+                            "Failed to compress image to png"
+                        }
+                    }
+                }.onSuccess {
+                    YLog.debug("$TAG: Saved png image to ${pngFile.absolutePath}")
+                }.onFailure {
+                    YLog.error("$TAG: Failed to save png image", it)
+                }
+
                 bitmap.recycle()
             }
         }
     }
 
     private fun installInjectPlayUrlIntoImageDownloadHook(): YukiMemberHookCreator.MemberHookCreator.Result? {
-        val packageInstance = DouyinPackage.instance
-
         return packageInstance.downloadAction.selfClass?.resolveMethod(
             packageInstance.downloadAction.startDownload()
         )?.hook {
@@ -203,10 +225,8 @@ object FeedMultiImageHooker : YukiBaseHooker() {
         }
     }
 
-    private fun installDisableSaveImageToVideoLocalWaterMaskHook(): YukiMemberHookCreator.MemberHookCreator.Result? {
-        val packageInstance = DouyinPackage.instance
-
-        return packageInstance.abTestServiceImpl.selfClass?.resolveMethod(
+    private fun installDisableSaveImageToVideoLocalWaterMaskHook(): YukiMemberHookCreator.MemberHookCreator.Result? =
+        packageInstance.abTestServiceImpl.selfClass?.resolveMethod(
             packageInstance.abTestServiceImpl.enableSaveImageToVideoLocalWaterMask()
         )?.hook {
             before {
@@ -221,5 +241,4 @@ object FeedMultiImageHooker : YukiBaseHooker() {
                 YLog.error("$TAG: hook failed, unable to remove watermark from save-image-to-video")
             }
         }
-    }
 }

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/FeedMultiImageHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/FeedMultiImageHooker.kt
@@ -47,23 +47,6 @@ object FeedMultiImageHooker : YukiBaseHooker() {
 
         installConvertVvicCoverImageToPngHook()
         installDisableVEAddLiveVideoWaterMarkHook()
-
-        packageInstance.imageResourceRxDownloadListener.selfClass?.resolveMethod(
-            packageInstance.imageResourceRxDownloadListener.onSuccessed()
-        )?.hook {
-            before {
-                val dlInfo = args[0] ?: return@before
-
-                val filePath = dlInfo.invokeMethod<String>(
-                    packageInstance.downloadInfo.getTargetFilePath()
-                )
-                if (filePath == null) {
-                    YLog.error("$TAG: target file path is null")
-                } else {
-                    YLog.debug("$TAG: file path: $filePath")
-                }
-            }
-        }
     }
 
     private fun installInjectPlayUrlIntoImageDownloadHook(): YukiMemberHookCreator.MemberHookCreator.Result? {

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/FeedMultiImageHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/FeedMultiImageHooker.kt
@@ -81,19 +81,21 @@ object FeedMultiImageHooker : YukiBaseHooker() {
                     return@before
                 }
 
-                val awemeId = aweme.invokeMethod<String>(
+                // skip if this post was already processed
+                aweme.invokeMethod<String>(
                     packageInstance.aweme.getAid()
-                )
-                if (ring.contains(awemeId)) {
-                    return@before
-                } else if (awemeId != null) {
-                    ring.add(awemeId)
+                )?.let {
+                    if (ring.contains(it)) {
+                        return@before
+                    }
+                    ring.add(it)
                 }
 
                 val awemeImages = aweme.getField<List<*>>(
                     packageInstance.aweme.images()
-                )
-                if (awemeImages.isNullOrEmpty()) {
+                ).takeIf {
+                    !it.isNullOrEmpty()
+                } ?: run {
                     YLog.error("$TAG: aweme.images is null or empty")
                     return@before
                 }
@@ -103,22 +105,56 @@ object FeedMultiImageHooker : YukiBaseHooker() {
                         return@forEach
                     }
 
-                    val urlList = imageStruct.getField<List<*>>(
+                    // use the play URL as the image download URL
+                    imageStruct.getField<List<*>>(
                         packageInstance.imageUrlStruct.urlList()
-                    )
-                    if (urlList.isNullOrEmpty()) {
-                        YLog.error("$TAG: image has no play URL, skipping watermark-free injection")
-                        return@forEach
-                    } else {
+                    ).takeIf {
+                        !it.isNullOrEmpty()
+                    }?.let {
+                        imageStruct.setField(
+                            packageInstance.imageUrlStruct.downloadUrlList(),
+                            it
+                        )
                         if (verbose) {
-                            YLog.debug("$TAG: image.urlList[0]: ${urlList.first()}")
+                            YLog.debug("$TAG: image.urlList[0]: ${it.first()}")
                         }
+                    } ?: run {
+                        YLog.warn("$TAG: image has no play URL, skipping watermark-free injection")
                     }
 
-                    imageStruct.setField(
-                        packageInstance.imageUrlStruct.downloadUrlList(),
-                        urlList
-                    )
+                    // also replace the video's download URL when the post has a video
+                    imageStruct.getField<Any>(
+                        packageInstance.imageUrlStruct.video()
+                    )?.let { video ->
+                        video.invokeMethod<Any>(
+                            packageInstance.video.getPlayAddr()
+                        )?.let { playAddr ->
+                            video.setField(
+                                packageInstance.video.downloadAddr(),
+                                playAddr
+                            )
+                            if (verbose) {
+                                YLog.debug(
+                                    "$TAG: play addr[0]: ${
+                                        playAddr.getField<List<String?>>(
+                                            packageInstance.urlModel.urlList()
+                                        )?.first {
+                                            !it.isNullOrBlank()
+                                        }
+                                    }"
+                                )
+                            }
+                        }?.also {
+                            video.setField(
+                                packageInstance.video.hasWaterMark(),
+                                false
+                            )
+                            video.setField(
+                                packageInstance.video.hasSuffixWaterMark(),
+                                false
+                            )
+                        }
+                    }
                 }
             }
         }?.result {

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/FeedMultiImageHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/FeedMultiImageHooker.kt
@@ -1,5 +1,10 @@
 package io.github.twyora.douyinenhancer.hook.feed
 
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.icu.text.RelativeDateTimeFormatter
+import android.os.strictmode.UntaggedSocketViolation
+import com.highcapable.kavaref.KavaRef.Companion.resolve
 import com.highcapable.yukihookapi.hook.core.YukiMemberHookCreator
 import com.highcapable.yukihookapi.hook.entity.YukiBaseHooker
 import com.highcapable.yukihookapi.hook.log.YLog
@@ -7,14 +12,22 @@ import io.github.twyora.douyinenhancer.config.FastKVConfigManager
 import io.github.twyora.douyinenhancer.config.key.SaveKey
 import io.github.twyora.douyinenhancer.hook.DouyinPackage
 import io.github.twyora.douyinenhancer.hook.HookOnMainProcess
+import io.github.twyora.douyinenhancer.utils.Field
+import io.github.twyora.douyinenhancer.utils.Method
 import io.github.twyora.douyinenhancer.utils.getField
+import io.github.twyora.douyinenhancer.utils.getStaticField
 import io.github.twyora.douyinenhancer.utils.invokeMethod
 import io.github.twyora.douyinenhancer.utils.resolveMethod
 import io.github.twyora.douyinenhancer.utils.setField
+import org.apache.commons.collections4.queue.CircularFifoQueue
+import java.io.FileInputStream
+import java.nio.file.Files
+import kotlin.io.path.Path
 
 @HookOnMainProcess
 object FeedMultiImageHooker : YukiBaseHooker() {
     private val TAG = this::class.simpleName
+    private val ring = CircularFifoQueue<String>(5)
 
     override fun onHook() {
         if (!FastKVConfigManager.settings.getBoolean(SaveKey.FEED_MULTI_IMAGE_REMOVE_WATERMARK, false)) {
@@ -23,6 +36,65 @@ object FeedMultiImageHooker : YukiBaseHooker() {
 
         installInjectPlayUrlIntoImageDownloadHook()
         installDisableSaveImageToVideoLocalWaterMaskHook()
+
+        val packageInstance = DouyinPackage.instance
+        packageInstance.imageResourceRxDownloadListener.selfClass?.resolveMethod(
+            packageInstance.imageResourceRxDownloadListener.onSuccessed()
+        )?.hook {
+            before {
+                val dlInfo = args[0] ?: return@before
+
+                val filePath = dlInfo.invokeMethod<String>(
+                    packageInstance.downloadInfo.getTargetFilePath()
+                )
+                if (filePath == null) {
+                    YLog.error("$TAG: target file path is null")
+                } else {
+                    YLog.debug("$TAG: file path: $filePath")
+                }
+            }
+        }
+
+        //LX/19xB;->LIZIZ(LX/19u9;)Z
+        "X.19xB".toClass().resolve().firstMethodOrNull {
+            name = "LIZIZ"
+        }?.hook {
+            before {
+                val _19u9 = args[0] ?: return@before
+                val imgFilePath = _19u9.getField<String>(
+                    Field(name = "LIZJ")
+                )
+                if (imgFilePath == null) {
+                    YLog.error("$TAG: imgFilePath is null")
+                    return@before
+                } else {
+                    YLog.debug("$TAG: imgFilePath: $imgFilePath")
+                }
+
+                val imgBytes = FileInputStream(imgFilePath).use {
+                    it.readBytes()
+                }
+                val options = BitmapFactory.Options()
+                options.inPreferredConfig = Bitmap.Config.ARGB_8888
+
+                val bitmap = "com.bytedance.fresco.heif.HeifDecoder".toClass().getStaticField<Any>(
+                    Field(name = "sBitmapFactory")
+                )?.invokeMethod<Bitmap>(
+                    Method(name = "decodeByteArray", parameters = null),
+                    imgBytes,
+                    0,
+                    imgBytes.size,
+                    options
+                )
+                if (bitmap == null) {
+                    YLog.error("$TAG: bitmap is null")
+                    return@before
+                } else {
+                    YLog.info("$TAG: bitmap nooooooooooot null!")
+                }
+                bitmap.recycle()
+            }
+        }
     }
 
     private fun installInjectPlayUrlIntoImageDownloadHook(): YukiMemberHookCreator.MemberHookCreator.Result? {
@@ -42,6 +114,15 @@ object FeedMultiImageHooker : YukiBaseHooker() {
                     return@before
                 }
 
+                val awemeId = aweme.invokeMethod<String>(
+                    packageInstance.aweme.getAid()
+                )
+                if (ring.contains(awemeId)) {
+                    return@before
+                } else if (awemeId != null) {
+                    ring.add(awemeId)
+                }
+
                 val awemeImages = aweme.getField<List<*>>(
                     packageInstance.aweme.images()
                 )
@@ -52,7 +133,7 @@ object FeedMultiImageHooker : YukiBaseHooker() {
 
                 awemeImages.forEach { imageStruct ->
                     if (imageStruct == null) {
-                        return@forEach
+                        return@before
                     }
 
                     val urlList = imageStruct.getField<List<*>>(
@@ -61,12 +142,55 @@ object FeedMultiImageHooker : YukiBaseHooker() {
                     if (urlList.isNullOrEmpty()) {
                         YLog.error("$TAG: image has no play URL, skipping watermark-free injection")
                         return@forEach
+                    } else {
+                        YLog.debug("$TAG: image.urlList[0]: ${urlList.first()}")
                     }
 
                     imageStruct.setField(
                         packageInstance.imageUrlStruct.downloadUrlList(),
                         urlList
                     )
+                    /*
+                    val downloadUrlList = imageStruct.getField<List<String>>(
+                        Field(name = "downloadUrlList")
+                    )
+                    val maskUrlList = imageStruct.getField<List<String>>(
+                        Field(name = "maskUrlList")
+                    )
+                    val urlList = imageStruct.getField<List<String>>(
+                        Field(name = "urlList")
+                    )
+                    val watermarkFreeDownloadUrlList = imageStruct.getField<List<String>>(
+                        Field(name = "watermarkFreeDownloadUrlList")
+                    )
+                    val imageExtra = imageStruct.getField<Any>(
+                        Field(name = "imageExtra")
+                    )
+                    val backupUrlList = imageExtra?.getField<List<String>>(
+                        Field(name = "backupUrlList")
+                    )
+
+                    YLog.debug(
+                        "$TAG: urlList: ${
+                            urlList?.firstOrNull()
+                        }, downloadUrlList: ${
+                            downloadUrlList?.firstOrNull()
+                        }, maskUrlList: ${
+                            maskUrlList?.firstOrNull()
+                        }, watermarkFreeDownloadUrlList: ${
+                            watermarkFreeDownloadUrlList?.firstOrNull()
+                        }, backupUrlList: ${
+                            backupUrlList?.firstOrNull()
+                        }"
+                    )
+                     */
+
+                    /*
+                    if (imageStruct == null) {
+                        return@forEach
+                    }
+
+                     */
                 }
             }
         }?.result {

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/FeedMultiImageHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/FeedMultiImageHooker.kt
@@ -2,7 +2,7 @@ package io.github.twyora.douyinenhancer.hook.feed
 
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
-import com.highcapable.kavaref.KavaRef.Companion.resolve
+import com.highcapable.kavaref.KavaRef.Companion.asResolver
 import com.highcapable.yukihookapi.hook.core.YukiMemberHookCreator
 import com.highcapable.yukihookapi.hook.entity.YukiBaseHooker
 import com.highcapable.yukihookapi.hook.log.YLog
@@ -10,9 +10,7 @@ import io.github.twyora.douyinenhancer.config.FastKVConfigManager
 import io.github.twyora.douyinenhancer.config.key.SaveKey
 import io.github.twyora.douyinenhancer.hook.DouyinPackage
 import io.github.twyora.douyinenhancer.hook.HookOnMainProcess
-import io.github.twyora.douyinenhancer.utils.Field
 import io.github.twyora.douyinenhancer.utils.FileTypeDetector
-import io.github.twyora.douyinenhancer.utils.Method
 import io.github.twyora.douyinenhancer.utils.getField
 import io.github.twyora.douyinenhancer.utils.getStaticField
 import io.github.twyora.douyinenhancer.utils.invokeMethod
@@ -41,6 +39,8 @@ object FeedMultiImageHooker : YukiBaseHooker() {
 
         installInjectPlayUrlIntoImageDownloadHook()
         installConvertVvicImageToPngHook()
+        installConvertSingleVvicImageToMp4Hook()
+        installConvertMultiVvicImageToMp4Hook()
         installDisableSaveImageToVideoLocalWaterMaskHook()
 
         packageInstance.imageResourceRxDownloadListener.selfClass?.resolveMethod(
@@ -155,69 +155,18 @@ object FeedMultiImageHooker : YukiBaseHooker() {
                 val imageFilePath = downloadTask.getField<String>(
                     packageInstance.downLoadTask.targetFilePath()
                 ) ?: run {
-                    YLog.error("$TAG: failed to get image file path from download task")
+                    YLog.error("$TAG: Failed to get image file path when downloading image")
                     return@before
                 }
 
                 val imageFile = File(imageFilePath)
                 if (!imageFile.exists()) {
-                    YLog.error("$TAG: image file does not exist")
-                    return@before
-                }
-                if (verbose) {
-                    YLog.debug("$TAG: image file absolute path: ${imageFile.absolutePath}")
-                }
-
-                val fvvicInfo = FileTypeDetector.detect(imageFile)
-                if (fvvicInfo.mimeType != "image/vvic") {
-                    if (verbose) {
-                        YLog.debug("$TAG: image is not in vvic format (got ${fvvicInfo.mimeType}), skipping")
-                    }
+                    YLog.error("$TAG: Image file does not exist when downloading image: ${imageFile.absolutePath}")
                     return@before
                 }
 
-                // convert to bitmap
-                val imageBytes = FileInputStream(imageFile).use {
-                    it.readBytes()
-                }
-                val bitmap = packageInstance.heifDecoder.selfClass?.getStaticField<Any>(
-                    packageInstance.heifDecoder.sBitmapFactory()
-                )?.invokeMethod<Bitmap>(
-                    packageInstance.heifBitmapFactoryImpl.decodeByteArray(),
-                    imageBytes,
-                    0,
-                    imageBytes.size,
-                    BitmapFactory.Options().apply {
-                        inPreferredConfig = Bitmap.Config.ARGB_8888
-                    }
-                ) ?: run {
-                    YLog.error("$TAG: failed to decode image to bitmap")
-                    return@before
-                }
-
-                // convert to png and overwrite the original image file
-                val pngFile = File(imageFilePath).run {
-                    resolveSibling("$nameWithoutExtension.png")
-                }
-                try {
-                    runCatching {
-                        pngFile.outputStream().use { out ->
-                            require(bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)) {
-                                "failed to compress image to png"
-                            }
-                        }
-                        imageFile.writeBytes(pngFile.readBytes())
-                    }.onSuccess {
-                        if (verbose) {
-                            YLog.debug("$TAG: saved png image to ${imageFile.absolutePath}")
-                        }
-                    }.onFailure {
-                        YLog.error("$TAG: failed to save png image", it)
-                    }.also {
-                        pngFile.delete()
-                    }
-                } finally {
-                    bitmap.recycle()
+                if (!overwriteVvicWithPng(imageFilePath)) {
+                    YLog.error("$TAG: Failed to convert vvic image to png when downloading image: $imageFilePath")
                 }
             }
         }?.result {
@@ -227,6 +176,132 @@ object FeedMultiImageHooker : YukiBaseHooker() {
             onHookingFailure {
                 YLog.error("$TAG: hook failed, vvic image to png conversion unavailable")
             }
+        }
+    }
+
+    private fun installConvertSingleVvicImageToMp4Hook(): YukiMemberHookCreator.MemberHookCreator.Result? {
+        return packageInstance.singleImageToMp4Composer.selfClass?.resolveMethod(
+            packageInstance.singleImageToMp4Composer.onLoad()
+        )?.hook {
+            before {
+                // The instance currently holds both image paths and music paths,
+                // which is hard to filter via DexKit during static analysis, so we can only defer it to runtime
+                val vvicImagePathList = instance.asResolver().field {
+                    type = String::class
+                }.mapNotNull {
+                    it.getQuietly<String>()
+                }.filter {
+                    it.isNotBlank() && File(it).exists() && FileTypeDetector.detect(it).mimeType == "image/vvic"
+                }
+
+                if (verbose) {
+                    YLog.debug("$TAG: vvic image path list: $vvicImagePathList")
+                }
+
+                vvicImagePathList.forEach {
+                    overwriteVvicWithPng(it)
+                }
+            }
+        }?.result {
+            onConductFailure { _, throwable ->
+                YLog.error("$TAG: failed to convert vvic image to png in mp4 composer", throwable)
+            }
+            onHookingFailure {
+                YLog.error("$TAG: hook failed, vvic image to png conversion in mp4 composer unavailable")
+            }
+        }
+    }
+
+    private fun installConvertMultiVvicImageToMp4Hook(): YukiMemberHookCreator.MemberHookCreator.Result? {
+        return packageInstance.multiImageToMp4Composer.selfClass?.resolveMethod(
+            packageInstance.multiImageToMp4Composer.onLoad()
+        )?.hook {
+            before {
+                val vvicImagePathList = instance.getField<List<List<String?>>>(
+                    packageInstance.multiImageToMp4Composer.imagePathList()
+                )?.flatten()?.filterNotNull()?.filter {
+                    it.isNotBlank() && File(it).exists() && FileTypeDetector.detect(it).mimeType == "image/vvic"
+                }
+
+                if (verbose) {
+                    YLog.debug("$TAG: vvic image path list: $vvicImagePathList")
+                }
+
+                vvicImagePathList?.forEach {
+                    overwriteVvicWithPng(it)
+                }
+            }
+        }?.result {
+            onConductFailure { _, throwable ->
+                YLog.error("$TAG: failed to convert vvic image to png in mutil mp4 composer", throwable)
+            }
+            onHookingFailure {
+                YLog.error("$TAG: hook failed, vvic image to png conversion in mutil mp4 composer unavailable")
+            }
+        }
+    }
+
+    private fun overwriteVvicWithPng(imageFilePath: String): Boolean {
+        val imageFile = File(imageFilePath)
+        if (!imageFile.exists()) {
+            YLog.error("$TAG: failed to overwrite vvic image, source file does not exist: ${imageFile.absolutePath}")
+            return false
+        }
+        if (verbose) {
+            YLog.debug("$TAG: image file absolute path: ${imageFile.absolutePath}")
+        }
+
+        val fvvicInfo = FileTypeDetector.detect(imageFile)
+        if (fvvicInfo.mimeType != "image/vvic") {
+            if (verbose) {
+                YLog.debug("$TAG: image is not in vvic format (got ${fvvicInfo.mimeType}), skipping")
+            }
+            return true
+        }
+
+        val imageBytes = runCatching {
+            FileInputStream(imageFile).use { it.readBytes() }
+        }.getOrElse {
+            YLog.error("$TAG: Failed to read vvic image for png conversion: ${imageFile.absolutePath}", it)
+            return false
+        }
+
+        val bitmap = packageInstance.heifDecoder.selfClass?.getStaticField<Any>(
+            packageInstance.heifDecoder.sBitmapFactory()
+        )?.invokeMethod<Bitmap>(
+            packageInstance.heifBitmapFactoryImpl.decodeByteArray(),
+            imageBytes,
+            0,
+            imageBytes.size,
+            BitmapFactory.Options().apply {
+                inPreferredConfig = Bitmap.Config.ARGB_8888
+            }
+        )
+        if (bitmap == null) {
+            YLog.error("$TAG: Failed to decode vvic image to bitmap: ${imageFile.absolutePath}")
+            return false
+        }
+
+        val pngFile = imageFile.resolveSibling("${imageFile.nameWithoutExtension}.png")
+        try {
+            runCatching {
+                pngFile.outputStream().use { out ->
+                    require(bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)) {
+                        "failed to compress vvic image to png"
+                    }
+                }
+                imageFile.writeBytes(pngFile.readBytes())
+            }.onFailure {
+                YLog.error("$TAG: failed to overwrite vvic image with png: ${imageFile.absolutePath}", it)
+                return false
+            }
+            if (verbose) {
+                YLog.debug("$TAG: converted vvic image to png: ${imageFile.absolutePath}")
+            }
+            return true
+        } finally {
+            bitmap.recycle()
+            pngFile.delete()
         }
     }
 }

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/FeedMultiImageHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/FeedMultiImageHooker.kt
@@ -26,10 +26,13 @@ import org.apache.commons.collections4.queue.CircularFifoQueue
 object FeedMultiImageHooker : YukiBaseHooker() {
     private val TAG = this::class.simpleName
 
-    private val ring = CircularFifoQueue<String>(5)
-
     private val packageInstance
         get() = DouyinPackage.instance
+
+    private val ring = CircularFifoQueue<String>(5)
+
+    // TODO: FastKVConfigManager.global.getBoolean("verbose", true)
+    private val verbose = false
 
     override fun onHook() {
         if (!FastKVConfigManager.settings.getBoolean(SaveKey.FEED_MULTI_IMAGE_REMOVE_WATERMARK, false)) {
@@ -37,6 +40,7 @@ object FeedMultiImageHooker : YukiBaseHooker() {
         }
 
         installInjectPlayUrlIntoImageDownloadHook()
+        installConvertVvicImageToPngHook()
         installDisableSaveImageToVideoLocalWaterMaskHook()
 
         packageInstance.imageResourceRxDownloadListener.selfClass?.resolveMethod(
@@ -53,70 +57,6 @@ object FeedMultiImageHooker : YukiBaseHooker() {
                 } else {
                     YLog.debug("$TAG: file path: $filePath")
                 }
-            }
-        }
-
-        packageInstance.downLoadExecutor.selfClass?.resolveMethod(
-            packageInstance.downLoadExecutor.execute()
-        )?.hook {
-            before {
-                val downloadTask = args[0] ?: return@before
-
-                val imageFilePath = downloadTask.getField<String>(
-                    packageInstance.downLoadTask.targetFilePath()
-                )
-                if (imageFilePath == null) {
-                    YLog.error("$TAG: Failed to get image file path from download task")
-                    return@before
-                }
-
-                val imageFile = File(imageFilePath)
-                if (!imageFile.exists()) {
-                    YLog.error("$TAG: Image file does not exist")
-                    return@before
-                }
-
-                val fvvicInfo = FileTypeDetector.detect(imageFile)
-                if (fvvicInfo.mimeType != "image/vvic") {
-                    YLog.debug("$TAG: Image is not in vvic format (got ${fvvicInfo.mimeType}), skipping")
-                    return@before
-                }
-
-                // convert to bitmap
-                val imageBytes = FileInputStream(imageFile).use {
-                    it.readBytes()
-                }
-                val bitmap = packageInstance.heifDecoder.selfClass?.getStaticField<Any>(
-                    packageInstance.heifDecoder.sBitmapFactory()
-                )?.invokeMethod<Bitmap>(
-                    packageInstance.heifBitmapFactoryImpl.decodeByteArray(),
-                    imageBytes,
-                    0,
-                    imageBytes.size,
-                    BitmapFactory.Options().apply {
-                        inPreferredConfig = Bitmap.Config.ARGB_8888
-                    }
-                )
-                if (bitmap == null) {
-                    YLog.error("$TAG: Failed to decode image to bitmap")
-                    return@before
-                }
-
-                // save bitmap as png alongside the original file
-                val pngFile = File(imageFilePath).run { resolveSibling("$nameWithoutExtension.png") }
-                runCatching {
-                    pngFile.outputStream().use { out ->
-                        require(bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)) {
-                            "Failed to compress image to png"
-                        }
-                    }
-                }.onSuccess {
-                    YLog.debug("$TAG: Saved png image to ${pngFile.absolutePath}")
-                }.onFailure {
-                    YLog.error("$TAG: Failed to save png image", it)
-                }
-
-                bitmap.recycle()
             }
         }
     }
@@ -155,7 +95,7 @@ object FeedMultiImageHooker : YukiBaseHooker() {
 
                 awemeImages.forEach { imageStruct ->
                     if (imageStruct == null) {
-                        return@before
+                        return@forEach
                     }
 
                     val urlList = imageStruct.getField<List<*>>(
@@ -165,54 +105,15 @@ object FeedMultiImageHooker : YukiBaseHooker() {
                         YLog.error("$TAG: image has no play URL, skipping watermark-free injection")
                         return@forEach
                     } else {
-                        YLog.debug("$TAG: image.urlList[0]: ${urlList.first()}")
+                        if (verbose) {
+                            YLog.debug("$TAG: image.urlList[0]: ${urlList.first()}")
+                        }
                     }
 
                     imageStruct.setField(
                         packageInstance.imageUrlStruct.downloadUrlList(),
                         urlList
                     )
-                    /*
-                    val downloadUrlList = imageStruct.getField<List<String>>(
-                        Field(name = "downloadUrlList")
-                    )
-                    val maskUrlList = imageStruct.getField<List<String>>(
-                        Field(name = "maskUrlList")
-                    )
-                    val urlList = imageStruct.getField<List<String>>(
-                        Field(name = "urlList")
-                    )
-                    val watermarkFreeDownloadUrlList = imageStruct.getField<List<String>>(
-                        Field(name = "watermarkFreeDownloadUrlList")
-                    )
-                    val imageExtra = imageStruct.getField<Any>(
-                        Field(name = "imageExtra")
-                    )
-                    val backupUrlList = imageExtra?.getField<List<String>>(
-                        Field(name = "backupUrlList")
-                    )
-
-                    YLog.debug(
-                        "$TAG: urlList: ${
-                            urlList?.firstOrNull()
-                        }, downloadUrlList: ${
-                            downloadUrlList?.firstOrNull()
-                        }, maskUrlList: ${
-                            maskUrlList?.firstOrNull()
-                        }, watermarkFreeDownloadUrlList: ${
-                            watermarkFreeDownloadUrlList?.firstOrNull()
-                        }, backupUrlList: ${
-                            backupUrlList?.firstOrNull()
-                        }"
-                    )
-                     */
-
-                    /*
-                    if (imageStruct == null) {
-                        return@forEach
-                    }
-
-                     */
                 }
             }
         }?.result {
@@ -230,7 +131,9 @@ object FeedMultiImageHooker : YukiBaseHooker() {
             packageInstance.abTestServiceImpl.enableSaveImageToVideoLocalWaterMask()
         )?.hook {
             before {
-                YLog.debug("$TAG: disabling local watermark for save-image-to-video")
+                if (verbose) {
+                    YLog.debug("$TAG: disabling local watermark for save-image-to-video")
+                }
                 resultFalse()
             }
         }?.result {
@@ -241,4 +144,89 @@ object FeedMultiImageHooker : YukiBaseHooker() {
                 YLog.error("$TAG: hook failed, unable to remove watermark from save-image-to-video")
             }
         }
+
+    private fun installConvertVvicImageToPngHook(): YukiMemberHookCreator.MemberHookCreator.Result? {
+        return packageInstance.downLoadExecutor.selfClass?.resolveMethod(
+            packageInstance.downLoadExecutor.execute()
+        )?.hook {
+            before {
+                val downloadTask = args[0] ?: return@before
+
+                val imageFilePath = downloadTask.getField<String>(
+                    packageInstance.downLoadTask.targetFilePath()
+                ) ?: run {
+                    YLog.error("$TAG: failed to get image file path from download task")
+                    return@before
+                }
+
+                val imageFile = File(imageFilePath)
+                if (!imageFile.exists()) {
+                    YLog.error("$TAG: image file does not exist")
+                    return@before
+                }
+                if (verbose) {
+                    YLog.debug("$TAG: image file absolute path: ${imageFile.absolutePath}")
+                }
+
+                val fvvicInfo = FileTypeDetector.detect(imageFile)
+                if (fvvicInfo.mimeType != "image/vvic") {
+                    if (verbose) {
+                        YLog.debug("$TAG: image is not in vvic format (got ${fvvicInfo.mimeType}), skipping")
+                    }
+                    return@before
+                }
+
+                // convert to bitmap
+                val imageBytes = FileInputStream(imageFile).use {
+                    it.readBytes()
+                }
+                val bitmap = packageInstance.heifDecoder.selfClass?.getStaticField<Any>(
+                    packageInstance.heifDecoder.sBitmapFactory()
+                )?.invokeMethod<Bitmap>(
+                    packageInstance.heifBitmapFactoryImpl.decodeByteArray(),
+                    imageBytes,
+                    0,
+                    imageBytes.size,
+                    BitmapFactory.Options().apply {
+                        inPreferredConfig = Bitmap.Config.ARGB_8888
+                    }
+                ) ?: run {
+                    YLog.error("$TAG: failed to decode image to bitmap")
+                    return@before
+                }
+
+                // convert to png and overwrite the original image file
+                val pngFile = File(imageFilePath).run {
+                    resolveSibling("$nameWithoutExtension.png")
+                }
+                try {
+                    runCatching {
+                        pngFile.outputStream().use { out ->
+                            require(bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)) {
+                                "failed to compress image to png"
+                            }
+                        }
+                        imageFile.writeBytes(pngFile.readBytes())
+                    }.onSuccess {
+                        if (verbose) {
+                            YLog.debug("$TAG: saved png image to ${imageFile.absolutePath}")
+                        }
+                    }.onFailure {
+                        YLog.error("$TAG: failed to save png image", it)
+                    }.also {
+                        pngFile.delete()
+                    }
+                } finally {
+                    bitmap.recycle()
+                }
+            }
+        }?.result {
+            onConductFailure { _, throwable ->
+                YLog.error("$TAG: failed to convert vvic image to png", throwable)
+            }
+            onHookingFailure {
+                YLog.error("$TAG: hook failed, vvic image to png conversion unavailable")
+            }
+        }
+    }
 }

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/FeedMultiImageHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/FeedMultiImageHooker.kt
@@ -27,8 +27,6 @@ object FeedMultiImageHooker : YukiBaseHooker() {
     private val packageInstance
         get() = DouyinPackage.instance
 
-    private val ring = CircularFifoQueue<String>(5)
-
     // TODO: FastKVConfigManager.global.getBoolean("verbose", true)
     private val verbose = false
 
@@ -42,7 +40,7 @@ object FeedMultiImageHooker : YukiBaseHooker() {
         installConvertVvicImageToPngHook()
 
         installConvertSingleVvicImageToMp4Hook()
-        installConvertMultiVvicImageToMp4Hook()
+        installConvertMultiVvicImagesToMp4Hook()
         installDisableSaveImageToVideoLocalWaterMaskHook()
 
         installConvertVvicCoverImageToPngHook()
@@ -53,6 +51,7 @@ object FeedMultiImageHooker : YukiBaseHooker() {
         return packageInstance.downloadAction.selfClass?.resolveMethod(
             packageInstance.downloadAction.startDownload()
         )?.hook {
+            val seenAwemeIds = CircularFifoQueue<String>(5)
             before {
                 val aweme = instance.getField<Any>(
                     packageInstance.downloadAction.aweme()
@@ -68,10 +67,10 @@ object FeedMultiImageHooker : YukiBaseHooker() {
                 aweme.invokeMethod<String>(
                     packageInstance.aweme.getAid()
                 )?.let {
-                    if (ring.contains(it)) {
+                    if (seenAwemeIds.contains(it)) {
                         return@before
                     }
-                    ring.add(it)
+                    seenAwemeIds.add(it)
                 }
 
                 val awemeImages = aweme.getField<List<*>>(
@@ -118,7 +117,7 @@ object FeedMultiImageHooker : YukiBaseHooker() {
                             )
                             if (verbose) {
                                 YLog.debug(
-                                    "$TAG: play addr[0]: ${
+                                    "$TAG:play URL used as video download address: ${
                                         playAddr.getField<List<String?>>(
                                             packageInstance.urlModel.urlList()
                                         )?.first {
@@ -187,7 +186,9 @@ object FeedMultiImageHooker : YukiBaseHooker() {
                 }
 
                 vvicImagePathList?.forEach {
-                    overwriteVvicWithPng(it)
+                    if (!overwriteVvicWithPng(it)) {
+                        YLog.error("$TAG: failed to convert vvic cover image to png: $it")
+                    }
                 }
             }
         }?.result {
@@ -205,6 +206,9 @@ object FeedMultiImageHooker : YukiBaseHooker() {
             packageInstance.abTestServiceImpl.enableVEAddLiveVideoWaterMark()
         )?.hook {
             before {
+                if (verbose) {
+                    YLog.debug("$TAG: disabling watermark for live video")
+                }
                 resultFalse()
             }
         }?.result {
@@ -254,7 +258,7 @@ object FeedMultiImageHooker : YukiBaseHooker() {
         )?.hook {
             before {
                 // The instance currently holds both image paths and music paths,
-                // which is hard to filter via DexKit during static analysis, so we can only defer it to runtime
+                // and during the DexKit lookup phase I can't tell them apart, so we have to defer it to runtime
                 val vvicImagePathList = instance.asResolver().field {
                     type = String::class
                 }.mapNotNull {
@@ -268,19 +272,21 @@ object FeedMultiImageHooker : YukiBaseHooker() {
                 }
 
                 vvicImagePathList.forEach {
-                    overwriteVvicWithPng(it)
+                    if (!overwriteVvicWithPng(it)) {
+                        YLog.error("$TAG: failed to convert single vvic image to png in mp4 composer: $it")
+                    }
                 }
             }
         }?.result {
             onConductFailure { _, throwable ->
-                YLog.error("$TAG: failed to convert vvic image to png in mp4 composer", throwable)
+                YLog.error("$TAG: failed to convert single vvic image to png in mp4 composer", throwable)
             }
             onHookingFailure {
-                YLog.error("$TAG: hook failed, vvic image to png conversion in mp4 composer unavailable")
+                YLog.error("$TAG: hook failed, single vvic image to png conversion in mp4 composer unavailable")
             }
         }
 
-    private fun installConvertMultiVvicImageToMp4Hook(): YukiMemberHookCreator.MemberHookCreator.Result? =
+    private fun installConvertMultiVvicImagesToMp4Hook(): YukiMemberHookCreator.MemberHookCreator.Result? =
         packageInstance.multiImageToMp4Composer.selfClass?.resolveMethod(
             packageInstance.multiImageToMp4Composer.onLoad()
         )?.hook {
@@ -296,15 +302,17 @@ object FeedMultiImageHooker : YukiBaseHooker() {
                 }
 
                 vvicImagePathList?.forEach {
-                    overwriteVvicWithPng(it)
+                    if (!overwriteVvicWithPng(it)) {
+                        YLog.error("$TAG: failed to convert multi vvic images to png in mp4 composer: $it")
+                    }
                 }
             }
         }?.result {
             onConductFailure { _, throwable ->
-                YLog.error("$TAG: failed to convert vvic image to png in mutil mp4 composer", throwable)
+                YLog.error("$TAG: failed to convert multi vvic images to png in mutil mp4 composer", throwable)
             }
             onHookingFailure {
-                YLog.error("$TAG: hook failed, vvic image to png conversion in mutil mp4 composer unavailable")
+                YLog.error("$TAG: hook failed, multi vvic images to png conversion in mp4 composer unavailable")
             }
         }
 
@@ -329,7 +337,7 @@ object FeedMultiImageHooker : YukiBaseHooker() {
         val imageBytes = runCatching {
             FileInputStream(imageFile).use { it.readBytes() }
         }.getOrElse {
-            YLog.error("$TAG: Failed to read vvic image for png conversion: ${imageFile.absolutePath}", it)
+            YLog.error("$TAG: failed to read vvic image for png conversion: ${imageFile.absolutePath}", it)
             return false
         }
 
@@ -345,7 +353,7 @@ object FeedMultiImageHooker : YukiBaseHooker() {
             }
         )
         if (bitmap == null) {
-            YLog.error("$TAG: Failed to decode vvic image to bitmap: ${imageFile.absolutePath}")
+            YLog.error("$TAG: failed to decode vvic image to bitmap: ${imageFile.absolutePath}")
             return false
         }
 

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/FeedMultiImageHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/FeedMultiImageHooker.kt
@@ -38,10 +38,15 @@ object FeedMultiImageHooker : YukiBaseHooker() {
         }
 
         installInjectPlayUrlIntoImageDownloadHook()
+
         installConvertVvicImageToPngHook()
+
         installConvertSingleVvicImageToMp4Hook()
         installConvertMultiVvicImageToMp4Hook()
         installDisableSaveImageToVideoLocalWaterMaskHook()
+
+        installConvertVvicCoverImageToPngHook()
+        installDisableVEAddLiveVideoWaterMarkHook()
 
         packageInstance.imageResourceRxDownloadListener.selfClass?.resolveMethod(
             packageInstance.imageResourceRxDownloadListener.onSuccessed()
@@ -145,6 +150,53 @@ object FeedMultiImageHooker : YukiBaseHooker() {
             }
         }
 
+    private fun installConvertVvicCoverImageToPngHook(): YukiMemberHookCreator.MemberHookCreator.Result? {
+        return packageInstance.downloadLivePhotoExecutor.selfClass?.resolveMethod(
+            packageInstance.downloadLivePhotoExecutor.encodeLivePhoto()
+        )?.hook {
+            before {
+                val downloadTask = args[0] ?: return@before
+
+                val vvicImagePathList = downloadTask.invokeMethod<List<String?>>(
+                    packageInstance.downLoadTask.getTargetFilePaths()
+                )?.filterNotNull()?.filter {
+                    it.isNotBlank() && File(it).exists() && FileTypeDetector.detect(it).mimeType == "image/vvic"
+                }
+
+                if (verbose) {
+                    YLog.debug("$TAG: vvic image path list: $vvicImagePathList")
+                }
+
+                vvicImagePathList?.forEach {
+                    overwriteVvicWithPng(it)
+                }
+            }
+        }?.result {
+            onConductFailure { _, throwable ->
+                YLog.error("$TAG: failed to convert vvic cover image to png", throwable)
+            }
+            onHookingFailure {
+                YLog.error("$TAG: hook failed, vvic cover image to png conversion unavailable")
+            }
+        }
+    }
+
+    private fun installDisableVEAddLiveVideoWaterMarkHook(): YukiMemberHookCreator.MemberHookCreator.Result? =
+        packageInstance.abTestServiceImpl.selfClass?.resolveMethod(
+            packageInstance.abTestServiceImpl.enableVEAddLiveVideoWaterMark()
+        )?.hook {
+            before {
+                resultFalse()
+            }
+        }?.result {
+            onConductFailure { _, throwable ->
+                YLog.error("$TAG: failed to hook ABTestServiceImpl.enableVEAddLiveVideoWaterMark", throwable)
+            }
+            onHookingFailure {
+                YLog.error("$TAG: hook failed, unable to remove watermark from live video")
+            }
+        }
+
     private fun installConvertVvicImageToPngHook(): YukiMemberHookCreator.MemberHookCreator.Result? {
         return packageInstance.downLoadExecutor.selfClass?.resolveMethod(
             packageInstance.downLoadExecutor.execute()
@@ -152,21 +204,19 @@ object FeedMultiImageHooker : YukiBaseHooker() {
             before {
                 val downloadTask = args[0] ?: return@before
 
-                val imageFilePath = downloadTask.getField<String>(
-                    packageInstance.downLoadTask.targetFilePath()
-                ) ?: run {
-                    YLog.error("$TAG: Failed to get image file path when downloading image")
+                val imageFilePath = downloadTask.invokeMethod<List<String?>>(
+                    packageInstance.downLoadTask.getTargetFilePaths()
+                )?.filterNotNull()?.filter {
+                    it.isNotBlank() && File(it).exists() && FileTypeDetector.detect(it).mimeType == "image/vvic"
+                } ?: run {
+                    YLog.error("$TAG: failed to get image file path when downloading image")
                     return@before
                 }
 
-                val imageFile = File(imageFilePath)
-                if (!imageFile.exists()) {
-                    YLog.error("$TAG: Image file does not exist when downloading image: ${imageFile.absolutePath}")
-                    return@before
-                }
-
-                if (!overwriteVvicWithPng(imageFilePath)) {
-                    YLog.error("$TAG: Failed to convert vvic image to png when downloading image: $imageFilePath")
+                imageFilePath.forEach {
+                    if (!overwriteVvicWithPng(it)) {
+                        YLog.error("$TAG: failed to convert vvic image to png when downloading image: $it")
+                    }
                 }
             }
         }?.result {
@@ -179,8 +229,8 @@ object FeedMultiImageHooker : YukiBaseHooker() {
         }
     }
 
-    private fun installConvertSingleVvicImageToMp4Hook(): YukiMemberHookCreator.MemberHookCreator.Result? {
-        return packageInstance.singleImageToMp4Composer.selfClass?.resolveMethod(
+    private fun installConvertSingleVvicImageToMp4Hook(): YukiMemberHookCreator.MemberHookCreator.Result? =
+        packageInstance.singleImageToMp4Composer.selfClass?.resolveMethod(
             packageInstance.singleImageToMp4Composer.onLoad()
         )?.hook {
             before {
@@ -210,10 +260,9 @@ object FeedMultiImageHooker : YukiBaseHooker() {
                 YLog.error("$TAG: hook failed, vvic image to png conversion in mp4 composer unavailable")
             }
         }
-    }
 
-    private fun installConvertMultiVvicImageToMp4Hook(): YukiMemberHookCreator.MemberHookCreator.Result? {
-        return packageInstance.multiImageToMp4Composer.selfClass?.resolveMethod(
+    private fun installConvertMultiVvicImageToMp4Hook(): YukiMemberHookCreator.MemberHookCreator.Result? =
+        packageInstance.multiImageToMp4Composer.selfClass?.resolveMethod(
             packageInstance.multiImageToMp4Composer.onLoad()
         )?.hook {
             before {
@@ -239,7 +288,6 @@ object FeedMultiImageHooker : YukiBaseHooker() {
                 YLog.error("$TAG: hook failed, vvic image to png conversion in mutil mp4 composer unavailable")
             }
         }
-    }
 
     private fun overwriteVvicWithPng(imageFilePath: String): Boolean {
         val imageFile = File(imageFilePath)

--- a/app/src/main/java/io/github/twyora/douyinenhancer/utils/FileTypeDetector.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/utils/FileTypeDetector.kt
@@ -19,6 +19,7 @@ object FileTypeDetector {
         val HEIC = FileTypeInfo("image/heic", listOf("heic", "heif"), "HEIF Image")
         val HEIF = FileTypeInfo("image/heif", listOf("heif"), "HEIF Image (MIF1)")
         val AVIF = FileTypeInfo("image/avif", listOf("avif"), "AVIF Image")
+        val VVIC = FileTypeInfo("image/vvic", listOf("vvic"), "VVIC Image")
         val ANI = FileTypeInfo("image/x-ani", listOf("ani"), "Animated Cursor")
 
         // Audio
@@ -133,6 +134,10 @@ object FileTypeDetector {
 
                 "mif1" -> {
                     MimeTypes.HEIF
+                }
+
+                "vvic" -> {
+                    MimeTypes.VVIC
                 }
 
                 "avif", "avis" -> {

--- a/app/src/main/proto/io/github/twyora/douyinenhancer/hook/configs.proto
+++ b/app/src/main/proto/io/github/twyora/douyinenhancer/hook/configs.proto
@@ -216,12 +216,6 @@ message LppDownloadModule {
   optional Method get_visibility = 2;
 }
 
-message ImageResourceRxDownloadListener {
-  optional Class class = 1;
-  optional Field observable_emitter = 2;
-  optional Method on_successed = 3;
-}
-
 message HeifDecoder {
   optional Class class = 1;
   optional Field s_bitmap_factory = 2;
@@ -293,7 +287,6 @@ message HookInfo {
   optional ABTestServiceImpl ab_test_service_impl = 31;
   optional LppDownloadModule lpp_download_module = 32;
   optional AwemeStatistics aweme_statistics = 33;
-  optional ImageResourceRxDownloadListener image_resource_rx_download_listener = 34;
   optional HeifDecoder heif_decoder = 35;
   optional HeifBitmapFactoryImpl heif_bitmap_factory_impl = 36;
   optional DownLoadExecutor down_load_executor = 37;

--- a/app/src/main/proto/io/github/twyora/douyinenhancer/hook/configs.proto
+++ b/app/src/main/proto/io/github/twyora/douyinenhancer/hook/configs.proto
@@ -237,6 +237,17 @@ message DownLoadTask {
   optional Field target_file_path = 2;
 }
 
+message SingleImageToMp4Composer {
+  optional Class class = 1;
+  optional Method on_load = 2;
+}
+
+message MultiImageToMp4Composer {
+  optional Class class = 1;
+  optional Method on_load = 2;
+  optional Field image_path_list = 3;
+}
+
 message HookInfo {
   uint64 last_update_time = 1;
   uint32 module_version_code = 2;
@@ -277,4 +288,6 @@ message HookInfo {
   optional HeifBitmapFactoryImpl heif_bitmap_factory_impl = 36;
   optional DownLoadExecutor down_load_executor = 37;
   optional DownLoadTask down_load_task = 38;
+  optional SingleImageToMp4Composer single_image_to_mp4_composer = 39;
+  optional MultiImageToMp4Composer multi_image_to_mp4_composer = 40;
 }

--- a/app/src/main/proto/io/github/twyora/douyinenhancer/hook/configs.proto
+++ b/app/src/main/proto/io/github/twyora/douyinenhancer/hook/configs.proto
@@ -204,6 +204,7 @@ message DownloadAction {
 message ABTestServiceImpl {
   optional Class class = 1;
   optional Method enable_save_image_to_video_local_water_mask = 2;
+  optional Method enableVEAddLiveVideoWaterMark = 3;
 }
 
 message LppDownloadModule {
@@ -234,7 +235,12 @@ message DownLoadExecutor {
 
 message DownLoadTask {
   optional Class class = 1;
-  optional Field target_file_path = 2;
+  optional Method get_target_file_paths = 2;
+}
+
+message DownloadLivePhotoExecutor {
+  optional Class class = 1;
+  optional Method encode_live_photo = 2;
 }
 
 message SingleImageToMp4Composer {
@@ -290,4 +296,5 @@ message HookInfo {
   optional DownLoadTask down_load_task = 38;
   optional SingleImageToMp4Composer single_image_to_mp4_composer = 39;
   optional MultiImageToMp4Composer multi_image_to_mp4_composer = 40;
+  optional DownloadLivePhotoExecutor download_live_photo_executor = 41;
 }

--- a/app/src/main/proto/io/github/twyora/douyinenhancer/hook/configs.proto
+++ b/app/src/main/proto/io/github/twyora/douyinenhancer/hook/configs.proto
@@ -171,6 +171,9 @@ message Aweme {
 message Video {
   optional Class class = 1;
   optional Method get_play_addr = 2;
+  optional Field has_suffix_water_mark = 3;
+  optional Field has_water_mark = 4;
+  optional Field download_addr = 5;
 }
 
 message ImageUrlStruct {
@@ -178,6 +181,7 @@ message ImageUrlStruct {
   optional Field watermark_free_download_url_list = 2;
   optional Field url_list = 3;
   optional Field download_url_list = 4;
+  optional Field video = 5;
 }
 
 message FeedResponseHandler {

--- a/app/src/main/proto/io/github/twyora/douyinenhancer/hook/configs.proto
+++ b/app/src/main/proto/io/github/twyora/douyinenhancer/hook/configs.proto
@@ -165,6 +165,7 @@ message Aweme {
   optional Method get_video = 12;
   optional Field images = 13;
   optional Field statistics = 14;
+  optional Method get_aid = 15;
 }
 
 message Video {
@@ -210,6 +211,12 @@ message LppDownloadModule {
   optional Method get_visibility = 2;
 }
 
+message ImageResourceRxDownloadListener{
+  optional Class class = 1;
+  optional Field observable_emitter = 2;
+  optional Method on_successed = 3;
+}
+
 message HookInfo {
   uint64 last_update_time = 1;
   uint32 module_version_code = 2;
@@ -245,4 +252,5 @@ message HookInfo {
   optional ABTestServiceImpl ab_test_service_impl = 31;
   optional LppDownloadModule lpp_download_module = 32;
   optional AwemeStatistics aweme_statistics = 33;
+  optional ImageResourceRxDownloadListener image_resource_rx_download_listener = 34;
 }

--- a/app/src/main/proto/io/github/twyora/douyinenhancer/hook/configs.proto
+++ b/app/src/main/proto/io/github/twyora/douyinenhancer/hook/configs.proto
@@ -217,6 +217,26 @@ message ImageResourceRxDownloadListener{
   optional Method on_successed = 3;
 }
 
+message HeifDecoder {
+  optional Class class = 1;
+  optional Field s_bitmap_factory = 2;
+}
+
+message HeifBitmapFactoryImpl {
+  optional Class class = 1;
+  optional Method decode_byte_array = 2;
+}
+
+message DownLoadExecutor {
+  optional Class class = 1;
+  optional Method execute = 2;
+}
+
+message DownLoadTask {
+  optional Class class = 1;
+  optional Field target_file_path = 2;
+}
+
 message HookInfo {
   uint64 last_update_time = 1;
   uint32 module_version_code = 2;
@@ -253,4 +273,8 @@ message HookInfo {
   optional LppDownloadModule lpp_download_module = 32;
   optional AwemeStatistics aweme_statistics = 33;
   optional ImageResourceRxDownloadListener image_resource_rx_download_listener = 34;
+  optional HeifDecoder heif_decoder = 35;
+  optional HeifBitmapFactoryImpl heif_bitmap_factory_impl = 36;
+  optional DownLoadExecutor down_load_executor = 37;
+  optional DownLoadTask down_load_task = 38;
 }

--- a/app/src/main/proto/io/github/twyora/douyinenhancer/hook/configs.proto
+++ b/app/src/main/proto/io/github/twyora/douyinenhancer/hook/configs.proto
@@ -211,7 +211,7 @@ message LppDownloadModule {
   optional Method get_visibility = 2;
 }
 
-message ImageResourceRxDownloadListener{
+message ImageResourceRxDownloadListener {
   optional Class class = 1;
   optional Field observable_emitter = 2;
   optional Method on_successed = 3;

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ auto-service-annotations = "1.1.0"
 auto-service-ksp = "1.2.0"
 jetbrainsKotlinJvm = "2.2.10"
 ksp-symbol-processing-api = "2.3.6"
+commonsCollections4 = "4.5.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -49,6 +50,7 @@ kotlinpoet-ksp = { module = "com.squareup:kotlinpoet-ksp", version.ref = "kotlin
 auto-service-annotations = { module = "com.google.auto.service:auto-service-annotations", version.ref = "auto-service-annotations" }
 auto-service-ksp = { module = "dev.zacsweers.autoservice:auto-service-ksp", version.ref = "auto-service-ksp" }
 ksp-symbol-processing-api = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "ksp-symbol-processing-api" }
+commons-collections4 = { group = "org.apache.commons", name = "commons-collections4", version.ref = "commonsCollections4" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Problem fixed:
Server-delivered vvic images cannot be previewed or used by users

## Fix:
Add vvic-to-png conversion so downloaded/saved images are in png format
- Decode downloaded vvic images and overwrite as PNG
- Apply the same conversion inside the single-image and multi-image to-mp4 composers before the host merges frames, preventing host merge failures
- Also convert the vvic cover image to PNG in the live-photo download executor

## New feature:
Watermark-free live photo saving
- Block the host from injecting watermark parameters into the merge pipeline
- When downloading a live photo, use the playback version instead of the default download version

fix #55