### PR TITLE
ci: post build apk to telegram with commit details

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -74,6 +74,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # referenced from [RestoreSplashScreen](https://github.com/GSWXXN/RestoreSplashScreen/blob/master/.github/workflows/android.yml)
       - name: Post Artifacts to Telegram
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         run: |

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -11,6 +11,11 @@ on:
       - "doc/*"
       - "LICENSE"
 
+permissions:
+  contents: read
+  actions: write
+  pull-requests: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -55,6 +55,38 @@ jobs:
           name: ${{ env.ARTIFACT_NAME }}
           path: ${{ env.APK_FILE }}
 
+      - name: Get Author Name
+        run: |
+          AUTHOR="${{ github.event.head_commit.author.name }}"
+          
+          PR_NUM=$(echo "${{ github.event.head_commit.message }}" | grep -oE '#[0-9]+' | head -n 1 | tr -d '#')
+          if [ -n "$PR_NUM" ]; then
+            PR_AUTHOR=$(gh pr view "$PR_NUM" --json author --jq '.author.login' 2>/dev/null)
+            [ -n "$PR_AUTHOR" ] && AUTHOR="$PR_AUTHOR"
+          fi
+          
+          echo "AUTHOR_NAME=$AUTHOR" >> "$GITHUB_ENV"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Post Artifacts to Telegram
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+        run: |
+          ESCAPED=`python3 -c 'import json,os,urllib.parse; msg = json.dumps(os.environ["COMMIT_MESSAGE"]); print(urllib.parse.quote(msg if len(msg) <= 1024 else json.dumps(os.environ["COMMIT_URL"])))'`
+          curl -v "https://api.telegram.org/bot${TG_BOT_TOKEN}/sendMediaGroup?chat_id=${TG_CHAT_ID}&media=%5b%7b%22type%22%3a%22document%22%2c+%22media%22%3a%22attach%3a%2f%2fci%22%2c%22caption%22%3a${ESCAPED}%7d%5d" -F ci="@${{ env.APK_FILE }}"
+        env:
+          TG_BOT_TOKEN: ${{ secrets.TG_BOT_TOKEN }}
+          TG_CHAT_ID: ${{ secrets.TG_CHAT_ID }}
+          COMMIT_MESSAGE: |+
+            New push to GitHub\!
+            ```
+            ${{ github.event.head_commit.message }}
+            ```by `${{ env.AUTHOR_NAME }}`
+            
+            See commit detail [here](${{ github.event.head_commit.url }})
+            See build detail [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          COMMIT_URL: ${{ github.event.head_commit.url }}
+
       - name: Display APK Hashes
         run: |
           apk=${{ env.APK_FILE }}


### PR DESCRIPTION
Add a Telegram step in android ci workflow that uploads the build APK with a caption of commit message