### PR TITLE
chore: polish hook logs, fix init order and code style

### DIFF
--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/DouyinPackage.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/DouyinPackage.kt
@@ -1676,7 +1676,7 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
                                     "[B",
                                     "int",
                                     "int",
-                                    "android.graphics.BitmapFactory\$Options"
+                                    $$"android.graphics.BitmapFactory$Options"
                                 )
                             )
                         }

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/DouyinPackage.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/DouyinPackage.kt
@@ -673,8 +673,8 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
         )
 
         fun enableVEAddLiveVideoWaterMark() = Method(
-            hookInfo.abTestServiceImpl.enableVEAddLiveVideoWaterMark.nameOrNull,
-            hookInfo.abTestServiceImpl.enableVEAddLiveVideoWaterMark.parameters.valuesListOrNull
+            hookInfo.abTestServiceImpl.enableVeAddLiveVideoWaterMark.nameOrNull,
+            hookInfo.abTestServiceImpl.enableVeAddLiveVideoWaterMark.parameters.valuesListOrNull
         )
     }
 
@@ -2149,7 +2149,7 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
                     enableSaveImageToVideoLocalWaterMask = method {
                         name = "enableSaveImageToVideoLocalWaterMask"
                     }
-                    enableVEAddLiveVideoWaterMark = method {
+                    enableVeAddLiveVideoWaterMark = method {
                         name = "enableVEAddLiveVideoWaterMark"
                     }
                 }

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/HookEntry.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/HookEntry.kt
@@ -38,9 +38,9 @@ object HookEntry : IYukiHookXposedInit {
                             return@before
                         }
 
+                        FastKVConfigManager.init(context)
                         // load cached HookInfo and run hooks when app context is available
                         DouyinPackage(appClassLoader!!, context)
-                        FastKVConfigManager.init(context)
 
                         YLog.info(
                             "verbose logging disabled is ${

--- a/app/src/main/proto/io/github/twyora/douyinenhancer/hook/configs.proto
+++ b/app/src/main/proto/io/github/twyora/douyinenhancer/hook/configs.proto
@@ -208,7 +208,7 @@ message DownloadAction {
 message ABTestServiceImpl {
   optional Class class = 1;
   optional Method enable_save_image_to_video_local_water_mask = 2;
-  optional Method enableVEAddLiveVideoWaterMark = 3;
+  optional Method enable_ve_add_live_video_water_mark = 3;
 }
 
 message LppDownloadModule {


### PR DESCRIPTION
- Initialize FastKVConfigManager before DouyinPackage to avoid accessing uninitialized lateinit properties
- Use `$$` prefix for `$` literal
- Rename `enableVEAddLiveVideoWaterMark` to snake_case in configs.proto
