### PR TITLE
feat: long-press "About Aweme" in settings to open module settings dialog

### DIFF
--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/DouyinPackage.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/DouyinPackage.kt
@@ -389,17 +389,18 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
 
     inner class MainActivityModule {
         val selfClass by weak {
-            "com.ss.android.ugc.aweme.main.MainActivity".toClassOrNull(classLoader)
+            hookInfo.mainActivity.class_.nameOrNull
+                ?.toClass(classLoader)
         }
 
         fun onResume() = Method(
-            "onResume",
-            null
+            hookInfo.mainActivity.onResume.nameOrNull,
+            hookInfo.mainActivity.onResume.parameters.valuesListOrNull
         )
 
         fun onNewIntent() = Method(
-            "onNewIntent",
-            listOf("android.content.Intent")
+            hookInfo.mainActivity.onNewIntent.nameOrNull,
+            hookInfo.mainActivity.onNewIntent.parameters.valuesListOrNull
         )
     }
 
@@ -2192,6 +2193,27 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
                         YLog.error("$TAG: unable to populate config", it)
                     }
                 }
+
+                mainActivity =
+                    mainActivity {
+                        class_ =
+                            class_ {
+                                name = "com.ss.android.ugc.aweme.main.MainActivity"
+                            }
+                        onResume =
+                            method {
+                                name = "onResume"
+                            }
+                        onNewIntent =
+                            method {
+                                name = "onNewIntent"
+                                parameters =
+                                    MethodKt.parameters {
+                                        values.clear()
+                                        values.add("android.content.Intent")
+                                    }
+                            }
+                    }
             }
         }
     }

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/settings/SettingsHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/settings/SettingsHooker.kt
@@ -2,12 +2,16 @@ package io.github.twyora.douyinenhancer.hook.settings
 
 import android.app.Activity
 import android.content.Context
+import android.service.voice.VoiceInteractionSession
 import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
+import com.highcapable.kavaref.extension.createInstance
+import com.highcapable.yukihookapi.hook.core.YukiMemberHookCreator
 import com.highcapable.yukihookapi.hook.entity.YukiBaseHooker
 import com.highcapable.yukihookapi.hook.factory.injectModuleAppResources
 import com.highcapable.yukihookapi.hook.log.YLog
+import com.highcapable.yukihookapi.hook.type.android.ActivityInfoClass
 import io.github.twyora.douyinenhancer.R
 import io.github.twyora.douyinenhancer.config.FastKVConfigManager
 import io.github.twyora.douyinenhancer.config.key.ModuleKey
@@ -29,40 +33,44 @@ object SettingsHooker : YukiBaseHooker() {
         get() = !FastKVConfigManager.module.getBoolean(ModuleKey.DISABLE_VERBOSE_LOGS, false)
 
     override fun onHook() {
-        packageInstance.douYinSettingNewVersionActivity.selfClass?.resolveMethod(
+        installModuleSettingsEntryHook()
+        installAboutMeLongClickOpenSettingsHook()
+    }
+
+    private fun installModuleSettingsEntryHook(): YukiMemberHookCreator.MemberHookCreator.Result? {
+        return packageInstance.douYinSettingNewVersionActivity.selfClass?.resolveMethod(
             packageInstance.douYinSettingNewVersionActivity.onResume()
         )?.hook {
             after {
-                val moduleSettingsTag = "dyenhancer_settings"
-
-                val activity = instance as? Activity ?: return@after
+                val activity = instance as? Activity ?: run {
+                    YLog.error("$TAG: ${instance::class.qualifiedName} is not an Activity")
+                    return@after
+                }
 
                 val settingsScrollView = instance.getField<ViewGroup?>(
                     packageInstance.douYinSettingNewVersionActivity.settingsScrollView()
                 ) ?: run {
-                    YLog.error("$TAG: settings scroll view field not found, cannot inject module entry")
+                    YLog.error("$TAG: settings scroll view field not found")
                     return@after
                 }
 
+                val moduleSettingsTag = "douyinenhancer_settings"
                 if (settingsScrollView.findViewWithTag<View>(moduleSettingsTag) != null) {
-                    if (verbose) {
-                        YLog.debug("$TAG: module settings entry already injected, skipping")
-                    }
+                    YLog.info("$TAG: module settings entry already present, skip to avoid duplicate entry")
                     return@after
                 }
 
                 val moduleSettingsCommonItemView =
-                    packageInstance.commonItemView.selfClass?.getConstructor(Context::class.java)
-                        ?.newInstance(instance) as? ViewGroup
-                if (moduleSettingsCommonItemView == null) {
-                    YLog.error("$TAG: failed to create module settings entry")
-                    return@after
+                    packageInstance.commonItemView.selfClass?.createInstance(activity) as? ViewGroup ?: run {
+                        YLog.error("$TAG: failed to create module settings entry")
+                        return@after
+                    }
+
+                moduleSettingsCommonItemView.apply {
+                    tag = moduleSettingsTag
+                    id = View.generateViewId()
                 }
-
-                moduleSettingsCommonItemView.tag = moduleSettingsTag
-                moduleSettingsCommonItemView.id = View.generateViewId()
-
-                // Ensure the host app can find the module settings icon
+                // ensure the host app can find the module settings icon
                 activity.injectModuleAppResources()
                 moduleSettingsCommonItemView.invokeMethod<Unit>(
                     packageInstance.commonItemView.setLeftTextAndIcon(),
@@ -82,10 +90,10 @@ object SettingsHooker : YukiBaseHooker() {
                     SettingsDialog.show(activity)
                 }
 
-                // Prefer inserting above the logout button; fallback to direct insert
-                val targetParent = settingsScrollView
-                    .findViewWithTag<View?>("logout")
-                    ?.parent as? ViewGroup
+                // prefer inserting above the logout button; fallback to direct insert
+                val targetParent = settingsScrollView.findViewWithTag<View?>(
+                    "logout"
+                )?.parent as? ViewGroup
                     ?: (settingsScrollView.getChildAt(0) as? ViewGroup)
                     ?: run {
                         YLog.error("$TAG: unable to find a suitable parent for module settings entry")
@@ -95,11 +103,43 @@ object SettingsHooker : YukiBaseHooker() {
                 if (verbose) {
                     YLog.debug("$TAG: module settings entry prepared, adding view to settings")
                 }
-
                 targetParent.addView(
                     moduleSettingsCommonItemView,
                     0
                 )
+            }
+        }
+    }
+
+    private fun installAboutMeLongClickOpenSettingsHook(): YukiMemberHookCreator.MemberHookCreator.Result? {
+        return packageInstance.douYinSettingNewVersionActivity.selfClass?.resolveMethod(
+            packageInstance.douYinSettingNewVersionActivity.onResume()
+        )?.hook {
+            after {
+                val activity = instance as? Activity ?: run {
+                    YLog.error("$TAG: ${instance::class.qualifiedName} is not an Activity")
+                    return@after
+                }
+
+                val settingsScrollView = activity.getField<ViewGroup>(
+                    packageInstance.douYinSettingNewVersionActivity.settingsScrollView()
+                ) ?: run {
+                    YLog.error("$TAG: settings scroll view field not found")
+                    return@after
+                }
+
+                val aboutMeView = settingsScrollView.findViewWithTag<View?>("about_ame") ?: run {
+                    YLog.error("$TAG: about_ame view not found by tag in settings scroll view")
+                    return@after
+                }
+
+                if (verbose) {
+                    YLog.debug("$TAG: attaching long click listener on about_ame view to open settings dialog")
+                }
+                aboutMeView.setOnLongClickListener {
+                    SettingsDialog.show(activity)
+                    true
+                }
             }
         }
     }

--- a/app/src/main/proto/io/github/twyora/douyinenhancer/hook/configs.proto
+++ b/app/src/main/proto/io/github/twyora/douyinenhancer/hook/configs.proto
@@ -252,6 +252,12 @@ message MultiImageToMp4Composer {
   optional Field image_path_list = 3;
 }
 
+message MainActivity {
+  optional Class class = 1;
+  optional Method on_resume = 2;
+  optional Method on_new_intent = 3;
+}
+
 message HookInfo {
   uint64 last_update_time = 1;
   uint32 module_version_code = 2;
@@ -294,4 +300,5 @@ message HookInfo {
   optional SingleImageToMp4Composer single_image_to_mp4_composer = 39;
   optional MultiImageToMp4Composer multi_image_to_mp4_composer = 40;
   optional DownloadLivePhotoExecutor download_live_photo_executor = 41;
+  optional MainActivity main_activity = 42;
 }


### PR DESCRIPTION
- Extract `installModuleSettingsEntryHook()` as a standalone method
- Add `installAboutMeLongClickOpenSettingsHook()`: long-pressing "About Aweme" in settings opens the module settings dialog
- Populate `mainActivity` via the proto DSL in `initHookInfo`, and switch `MainActivityModule` to read the config from `hookInfo` instead of the previous hard-coded values