### PR TITLE
feat: bypass recommended feed save restrictions

### DIFF
--- a/app/src/main/java/io/github/twyora/douyinenhancer/config/key/SaveKey.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/config/key/SaveKey.kt
@@ -6,4 +6,5 @@ object SaveKey {
     const val DOWNLOAD_COMMENT_AUDIO = "download_comment_audio"
     const val FEED_VIDEO_REMOVE_WATERMARK = "feed_video_remove_watermark"
     const val FEED_MULTI_IMAGE_REMOVE_WATERMARK = "feed_multi_image_remove_watermark"
+    const val FEED_DOWNLOAD_BYPASS = "feed_download_bypass"
 }

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/DouyinPackage.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/DouyinPackage.kt
@@ -117,6 +117,13 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
     val singleImageToMp4Composer = SingleImageToMp4ComposerModule()
     val multiImageToMp4Composer = MultiImageToMp4ComposerModule()
     val mainActivity = MainActivityModule()
+    val absPermissionChecker = AbsPermissionCheckerModule()
+    val actionCheckResult = ActionCheckResultModule()
+    val actionStatus = ActionStatusModule()
+    val galleryShareHelper = GalleryShareHelperModule()
+    val awemeStatus = AwemeStatusModule()
+    val sharePrivacyVideoApi = SharePrivacyVideoApiModule()
+    val rxObservable = RxObservableModule()
 
     inner class CommentImageStructModule {
         val selfClass by weak {
@@ -468,6 +475,61 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
             hookInfo.aweme.getAid.nameOrNull,
             hookInfo.aweme.getAid.parameters.valuesListOrNull
         )
+
+        fun getDownloadStatus() = Method(
+            hookInfo.aweme.getDownloadStatus.nameOrNull,
+            hookInfo.aweme.getDownloadStatus.parameters.valuesListOrNull
+        )
+
+        fun aid() = Field(hookInfo.aweme.aid.nameOrNull)
+
+        fun status() = Field(hookInfo.aweme.status.nameOrNull)
+    }
+
+    inner class AwemeStatusModule {
+        val selfClass by weak {
+            hookInfo.awemeStatus.class_.nameOrNull
+                ?.toClass(classLoader)
+        }
+
+        fun downloadStatus() = Field(hookInfo.awemeStatus.downloadStatus.nameOrNull)
+    }
+
+    inner class SharePrivacyVideoApiModule {
+        val selfClass by weak {
+            hookInfo.sharePrivacyVideoApi.class_.nameOrNull
+                ?.toClass(classLoader)
+        }
+
+        fun getDownloadStatus() = Method(
+            hookInfo.sharePrivacyVideoApi.getDownloadStatus.nameOrNull,
+            hookInfo.sharePrivacyVideoApi.getDownloadStatus.parameters.valuesListOrNull
+        )
+
+        val privacyVideoResponse = SharePrivacyVideoResponseModule()
+
+        inner class SharePrivacyVideoResponseModule {
+            val selfClass by weak {
+                hookInfo.sharePrivacyVideoApi.privacyVideoResponse.class_.nameOrNull
+                    ?.toClass(classLoader)
+            }
+
+            fun msg() = Field(hookInfo.sharePrivacyVideoApi.privacyVideoResponse.msg.nameOrNull)
+
+            fun status() = Field(hookInfo.sharePrivacyVideoApi.privacyVideoResponse.status.nameOrNull)
+        }
+    }
+
+    inner class RxObservableModule {
+        val selfClass by weak {
+            hookInfo.rxObservable.class_.nameOrNull
+                ?.toClass(classLoader)
+        }
+
+        fun just() = Method(
+            hookInfo.rxObservable.just.nameOrNull,
+            hookInfo.rxObservable.just.parameters.valuesListOrNull
+        )
     }
 
     inner class AwemeStatisticsModule {
@@ -687,6 +749,57 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
         fun getVisibility() = Method(
             hookInfo.lppDownloadModule.getVisibility.nameOrNull,
             hookInfo.lppDownloadModule.getVisibility.parameters.valuesListOrNull
+        )
+    }
+
+    inner class AbsPermissionCheckerModule {
+        val selfClass by weak {
+            hookInfo.absPermissionChecker.class_.nameOrNull
+                ?.toClass(classLoader)
+        }
+
+        fun getActionCheckResult() = Method(
+            hookInfo.absPermissionChecker.getActionCheckResult.nameOrNull,
+            hookInfo.absPermissionChecker.getActionCheckResult.parameters.valuesListOrNull
+        )
+    }
+
+    inner class ActionCheckResultModule {
+        val selfClass by weak {
+            hookInfo.actionCheckResult.class_.nameOrNull
+                ?.toClass(classLoader)
+        }
+
+        fun actionStatus() = Field(hookInfo.actionCheckResult.actionStatus.nameOrNull)
+    }
+
+    inner class ActionStatusModule {
+        val selfClass by weak {
+            hookInfo.actionStatus.class_.nameOrNull
+                ?.toClass(classLoader)
+        }
+
+        fun valueOf() = Method(
+            hookInfo.actionStatus.valueOf.nameOrNull,
+            hookInfo.actionStatus.valueOf.parameters.valuesListOrNull
+        )
+
+        fun grayed() = Field(hookInfo.actionStatus.grayed.nameOrNull)
+
+        fun hidden() = Field(hookInfo.actionStatus.hidden.nameOrNull)
+
+        fun normal() = Field(hookInfo.actionStatus.normal.nameOrNull)
+    }
+
+    inner class GalleryShareHelperModule {
+        val selfClass by weak {
+            hookInfo.galleryShareHelper.class_.nameOrNull
+                ?.toClass(classLoader)
+        }
+
+        fun startDownload() = Method(
+            hookInfo.galleryShareHelper.startDownload.nameOrNull,
+            hookInfo.galleryShareHelper.startDownload.parameters.valuesListOrNull
         )
     }
 
@@ -1634,6 +1747,15 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
                     getAid = method {
                         name = "getAid"
                     }
+                    getDownloadStatus = method {
+                        name = "getDownloadStatus"
+                    }
+                    aid = field {
+                        name = "aid"
+                    }
+                    status = field {
+                        name = "status"
+                    }
                 }
 
                 awemeStatistics = awemeStatistics {
@@ -2190,6 +2312,202 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
                         }
                     }.onFailure {
                         YLog.error("$TAG: unable to populate config", it)
+                    }
+                }
+
+                absPermissionChecker =
+                    absPermissionChecker {
+                        runCatching {
+                            val clsName =
+                                "com.ss.android.ugc.aweme.permission.AbsPermissionChecker"
+                            val getActionCheckResultData = bridge.findMethod {
+                                matcher {
+                                    declaredClass = clsName
+                                    modifiers = Modifier.PUBLIC or Modifier.FINAL
+                                    usingStrings {
+                                        add("getActionCheckResult")
+                                    }
+                                }
+                            }.singleOrNull() ?: run {
+                                YLog.error(
+                                    "$TAG: unable to populate ${this::class.java.enclosingClass?.simpleName} config, possibly due to unfound obfuscated methods"
+                                )
+                                return@absPermissionChecker
+                            }
+
+                            class_ = class_ {
+                                name = clsName
+                            }
+                            getActionCheckResult = method {
+                                name = getActionCheckResultData.methodName
+                                parameters = MethodKt.parameters {
+                                    values.clear()
+                                    values.addAll(getActionCheckResultData.paramTypeNames)
+                                }
+                            }
+
+                            this@hookInfo.actionCheckResult = actionCheckResult {
+                                runCatching {
+                                    val actionCheckResultClsName = getActionCheckResultData.returnType!!.name
+                                    val actionCheckResultActionStatusFieldName =
+                                        actionCheckResultClsName.toClass(hostAppClassLoader).resolve().firstFieldOrNull {
+                                            type = "com.ss.android.ugc.aweme.privacy.model.ActionStatus"
+                                        }?.self?.name ?: run {
+                                            YLog.error(
+                                                "$TAG: unable to populate ${this::class.java.enclosingClass?.simpleName} config, possibly due to unfound obfuscated methods"
+                                            )
+                                            return@actionCheckResult
+                                        }
+
+                                    class_ = class_ {
+                                        name = actionCheckResultClsName
+                                    }
+                                    actionStatus = field {
+                                        name = actionCheckResultActionStatusFieldName
+                                    }
+                                }.onFailure {
+                                    YLog.error("$TAG: unable to populate config", it)
+                                }
+                            }
+                        }.onFailure {
+                            YLog.error("$TAG: unable to populate config", it)
+                        }
+                    }
+
+                actionStatus =
+                    actionStatus {
+                        class_ = class_ {
+                            name = "com.ss.android.ugc.aweme.privacy.model.ActionStatus"
+                        }
+                        valueOf = method {
+                            name = "valueOf"
+                        }
+                        grayed = field {
+                            name = "GRAYED"
+                        }
+                        hidden = field {
+                            name = "HIDDEN"
+                        }
+                        normal = field {
+                            name = "NORMAL"
+                        }
+                    }
+
+                galleryShareHelper =
+                    galleryShareHelper {
+                        runCatching {
+                            val startDownloadData = bridge.findMethod {
+                                matcher {
+                                    modifiers = Modifier.PUBLIC or Modifier.FINAL
+                                    returnType = "void"
+                                    params {
+                                        add("com.ss.android.ugc.aweme.feed.model.Aweme")
+                                        add("java.lang.String")
+                                    }
+                                    invokeMethods {
+                                        add {
+                                            descriptor =
+                                                "Lcom/ss/android/ugc/aweme/feed/model/Aweme;->getVideo()Lcom/ss/android/ugc/aweme/feed/model/Video;"
+                                        }
+                                        add {
+                                            descriptor =
+                                                "Lcom/ss/android/common/util/NetworkUtils;->isNetworkAvailable(Landroid/content/Context;)Z"
+                                        }
+                                        add {
+                                            descriptor = "Lcom/ss/android/ugc/aweme/feed/model/Aweme;->getDownloadStatus()I"
+                                        }
+                                        add {
+                                            descriptor = "Lcom/ss/android/ugc/aweme/feed/model/Aweme;->getAid()Ljava/lang/String;"
+                                        }
+                                    }
+                                }
+                            }.singleOrNull() ?: run {
+                                YLog.error(
+                                    "$TAG: unable to populate ${this::class.java.enclosingClass.simpleName} config, possibly due to unfound obfuscated methods"
+                                )
+                                return@galleryShareHelper
+                            }
+
+                            class_ = class_ {
+                                name = startDownloadData.className
+                            }
+                            startDownload = method {
+                                name = startDownloadData.methodName
+                                parameters = MethodKt.parameters {
+                                    values.clear()
+                                    values.addAll(startDownloadData.paramTypeNames)
+                                }
+                            }
+                        }.onFailure {
+                            YLog.error("$TAG: unable to populate config", it)
+                        }
+                    }
+
+                awemeStatus =
+                    awemeStatus {
+                        class_ = class_ {
+                            name = "com.ss.android.ugc.aweme.feed.model.AwemeStatus"
+                        }
+                        downloadStatus = field {
+                            name = "downloadStatus"
+                        }
+                    }
+
+                sharePrivacyVideoApi =
+                    sharePrivacyVideoApi {
+                        runCatching {
+                            val getDownloadStatusMethodName =
+                                "com.ss.android.ugc.aweme.feed.share.video.SharePrivacyVideoApi"
+                                    .toClass(hostAppClassLoader)
+                                    .resolve()
+                                    .firstMethodOrNull {
+                                        modifiers(Modifiers.PUBLIC, Modifiers.STATIC, Modifiers.FINAL)
+                                        returnType = "io.reactivex.Observable"
+                                    }?.self?.name
+                            if (getDownloadStatusMethodName == null) {
+                                YLog.error(
+                                    "$TAG: unable to populate ${this::class.java.enclosingClass?.simpleName} config, possibly due to unfound obfuscated methods"
+                                )
+                                return@sharePrivacyVideoApi
+                            }
+
+                            class_ =
+                                class_ {
+                                    name = "com.ss.android.ugc.aweme.feed.share.video.SharePrivacyVideoApi"
+                                }
+                            privacyVideoResponse =
+                                sharePrivacyVideoResponse {
+                                    class_ =
+                                        class_ {
+                                            name = "com.ss.android.ugc.aweme.feed.share.video.SharePrivacyVideoApi\$PrivacyVideoResponse"
+                                        }
+                                    msg =
+                                        field {
+                                            name = "msg"
+                                        }
+                                    status =
+                                        field {
+                                            name = "status"
+                                        }
+                                }
+                            getDownloadStatus =
+                                method {
+                                    name = getDownloadStatusMethodName
+                                }
+                        }.onFailure {
+                            YLog.error("$TAG: unable to populate config", it)
+                        }
+                    }
+
+                rxObservable = rxObservable {
+                    class_ = class_ {
+                        name = "io.reactivex.Observable"
+                    }
+                    just = method {
+                        name = "just"
+                        parameters = MethodKt.parameters {
+                            values.add("java.lang.Object")
+                        }
                     }
                 }
             }

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/DouyinPackage.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/DouyinPackage.kt
@@ -107,7 +107,6 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
     val miscDownloadAddrUtil = MiscDownloadAddrUtilModule()
     val downloadAction = DownloadActionModule()
     val abTestServiceImpl = ABTestServiceImplModule()
-    val lppDownloadModule = LppDownloadModuleModule()
     val awemeStatistics = AwemeStatisticsModule()
     val heifDecoder = HeifDecoderModule()
     val heifBitmapFactoryImpl = HeifBitmapFactoryImplModule()
@@ -737,18 +736,6 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
         fun enableVEAddLiveVideoWaterMark() = Method(
             hookInfo.abTestServiceImpl.enableVEAddLiveVideoWaterMark.nameOrNull,
             hookInfo.abTestServiceImpl.enableVEAddLiveVideoWaterMark.parameters.valuesListOrNull
-        )
-    }
-
-    inner class LppDownloadModuleModule {
-        val selfClass by weak {
-            hookInfo.lppDownloadModule.class_.nameOrNull
-                ?.toClass(classLoader)
-        }
-
-        fun getVisibility() = Method(
-            hookInfo.lppDownloadModule.getVisibility.nameOrNull,
-            hookInfo.lppDownloadModule.getVisibility.parameters.valuesListOrNull
         )
     }
 
@@ -2273,45 +2260,6 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
                     }
                     enableVEAddLiveVideoWaterMark = method {
                         name = "enableVEAddLiveVideoWaterMark"
-                    }
-                }
-
-                lppDownloadModule = lppDownloadModule {
-                    runCatching {
-                        val lppDownloadModuleClsName =
-                            "com.ss.android.ugc.aweme.feed.long_press_panel.modules.business.homepage.LppDownloadModule"
-                        val getVisibilityMethod = lppDownloadModuleClsName
-                            .toClass(hostAppClassLoader)
-                            .resolve()
-                            .firstMethodOrNull {
-                                modifiers(Modifiers.PUBLIC, Modifiers.FINAL)
-                                parameters(
-                                    "com.ss.android.ugc.aweme.feed.long_press_panel.model.LongPressPanelParams"
-                                )
-                                returnType = Int::class.java
-                            }?.self
-
-                        if (getVisibilityMethod == null) {
-                            YLog.error(
-                                "$TAG: unable to populate ${this::class.java.enclosingClass?.simpleName} config, possibly due to unfound obfuscated methods"
-                            )
-                            return@lppDownloadModule
-                        }
-
-                        class_ = class_ {
-                            name = lppDownloadModuleClsName
-                        }
-                        getVisibility = method {
-                            name = getVisibilityMethod.name
-                            parameters = MethodKt.parameters {
-                                values.clear()
-                                getVisibilityMethod.parameterTypes.forEach { paramType ->
-                                    values.add(paramType.name)
-                                }
-                            }
-                        }
-                    }.onFailure {
-                        YLog.error("$TAG: unable to populate config", it)
                     }
                 }
 

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/FeedDownloadHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/FeedDownloadHooker.kt
@@ -6,6 +6,7 @@ import com.highcapable.yukihookapi.hook.entity.YukiBaseHooker
 import com.highcapable.yukihookapi.hook.log.YLog
 import io.github.twyora.douyinenhancer.config.FastKVConfigManager
 import io.github.twyora.douyinenhancer.config.key.ModuleKey
+import io.github.twyora.douyinenhancer.config.key.SaveKey
 import io.github.twyora.douyinenhancer.hook.DouyinPackage
 import io.github.twyora.douyinenhancer.hook.HookOnMainProcess
 import io.github.twyora.douyinenhancer.utils.HookTransaction
@@ -26,6 +27,12 @@ object FeedDownloadHooker : YukiBaseHooker() {
         get() = !FastKVConfigManager.module.getBoolean(ModuleKey.DISABLE_VERBOSE_LOGS, false)
 
     override fun onHook() {
+        if (!FastKVConfigManager.settings.getBoolean(SaveKey.FEED_DOWNLOAD_BYPASS, false)) {
+            if (verbose) {
+                YLog.debug("$TAG: feed download bypass disabled, skip feed download hooks")
+            }
+            return
+        }
         val transaction = HookTransaction(TAG)
 
         transaction.add(::installForceActionStatusNormalHook.name) {
@@ -47,7 +54,9 @@ object FeedDownloadHooker : YukiBaseHooker() {
         )?.hook {
             after {
                 val actionCheckResult = result ?: run {
-                    YLog.warn("$TAG: action permission check result is null, cannot force action status to allowed, download may be blocked")
+                    YLog.warn(
+                        "$TAG: action permission check result is null, cannot force action status to allowed, download may be blocked"
+                    )
                     return@after
                 }
                 val actionStatus = actionCheckResult.getField<Any>(

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/FeedDownloadHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/FeedDownloadHooker.kt
@@ -16,7 +16,7 @@ import io.github.twyora.douyinenhancer.utils.resolveMethod
 import io.github.twyora.douyinenhancer.utils.setField
 
 @HookOnMainProcess
-object FeedDownloadModuleHooker : YukiBaseHooker() {
+object FeedDownloadHooker : YukiBaseHooker() {
     private val TAG = this::class.simpleName
 
     private val packageInstance

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/FeedDownloadModuleHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/FeedDownloadModuleHooker.kt
@@ -1,11 +1,17 @@
 package io.github.twyora.douyinenhancer.hook.feed
 
-import android.view.View
+import com.highcapable.kavaref.extension.createInstance
 import com.highcapable.yukihookapi.hook.entity.YukiBaseHooker
 import com.highcapable.yukihookapi.hook.log.YLog
+import io.github.twyora.douyinenhancer.config.FastKVConfigManager
+import io.github.twyora.douyinenhancer.config.key.ModuleKey
 import io.github.twyora.douyinenhancer.hook.DouyinPackage
 import io.github.twyora.douyinenhancer.hook.HookOnMainProcess
+import io.github.twyora.douyinenhancer.utils.getField
+import io.github.twyora.douyinenhancer.utils.invokeMethod
+import io.github.twyora.douyinenhancer.utils.invokeStaticMethod
 import io.github.twyora.douyinenhancer.utils.resolveMethod
+import io.github.twyora.douyinenhancer.utils.setField
 
 @HookOnMainProcess
 object FeedDownloadModuleHooker : YukiBaseHooker() {
@@ -14,23 +20,94 @@ object FeedDownloadModuleHooker : YukiBaseHooker() {
     private val packageInstance
         get() = DouyinPackage.instance
 
+    private val verbose
+        get() = !FastKVConfigManager.module.getBoolean(ModuleKey.DISABLE_VERBOSE_LOGS, false)
+
     override fun onHook() {
-        packageInstance.lppDownloadModule.selfClass?.resolveMethod(
-            packageInstance.lppDownloadModule.getVisibility()
+        packageInstance.absPermissionChecker.selfClass?.resolveMethod(
+            packageInstance.absPermissionChecker.getActionCheckResult()
         )?.hook {
             after {
-                val visibility = result as? Int ?: return@after
-                if (visibility == View.VISIBLE) {
+                val actionCheckResult = result ?: run {
+                    YLog.warn("$TAG: getActionCheckResult of AbsPermissionChecker returned null, cannot override action status")
+                    return@after
+                }
+                val actionStatus = actionCheckResult.getField<Any>(
+                    packageInstance.actionCheckResult.actionStatus()
+                ) ?: run {
+                    YLog.warn("$TAG: actionStatus field of ActionCheckResult returned null, cannot read action status")
                     return@after
                 }
 
-                // TODO: Kinda tired of staring at this thing, and honestly
-                // the author doesn't really need to download restricted content that often,
-                // so let's just pick some low-hanging fruit first —
-                // this one can wait till next time, hehe (^///^)
-                YLog.warn(
-                    "$TAG: feed download button is hidden by the host and the hook logic hasn't been implemented yet — the download button will remain hidden!"
+                val normalStatus = packageInstance.actionStatus.selfClass?.invokeStaticMethod<Any>(
+                    packageInstance.actionStatus.valueOf(),
+                    packageInstance.actionStatus.normal().name
                 )
+
+                if (verbose) {
+                    YLog.debug("$TAG: permission check actionStatus is $actionStatus")
+                }
+
+                if (actionStatus != normalStatus) {
+                    YLog.info("$TAG: actionStatus is $actionStatus, override to $normalStatus")
+                    actionCheckResult.setField(
+                        packageInstance.actionCheckResult.actionStatus(),
+                        normalStatus
+                    )
+                }
+            }
+        }
+
+        packageInstance.galleryShareHelper.selfClass?.resolveMethod(
+            packageInstance.galleryShareHelper.startDownload()
+        )?.hook {
+            before {
+                val aweme = args[0] ?: return@before
+                val downloadStatus = aweme.invokeMethod<Int>(
+                    packageInstance.aweme.getDownloadStatus()
+                )
+
+                if (verbose) {
+                    YLog.debug("$TAG: aweme downloadStatus is $downloadStatus")
+                }
+
+                if (downloadStatus != 0) {
+                    YLog.info("$TAG: overriding download status of aweme from $downloadStatus to 0")
+                    aweme.getField<Any>(
+                        packageInstance.aweme.status()
+                    )?.setField(
+                        packageInstance.awemeStatus.downloadStatus(),
+                        0
+                    )
+                }
+            }
+        }
+
+        packageInstance.sharePrivacyVideoApi.selfClass?.resolveMethod(
+            packageInstance.sharePrivacyVideoApi.getDownloadStatus()
+        )?.hook {
+            before {
+                val response = packageInstance.sharePrivacyVideoApi.privacyVideoResponse.selfClass?.createInstance() ?: run {
+                    YLog.error("$TAG: failed to create privacyVideoResponse, cannot set allowed download status")
+                    return@before
+                }
+                response.setField(
+                    packageInstance.sharePrivacyVideoApi.privacyVideoResponse.msg(),
+                    ""
+                )
+                response.setField(
+                    packageInstance.sharePrivacyVideoApi.privacyVideoResponse.status(),
+                    0
+                )
+
+                val observable = packageInstance.rxObservable.selfClass?.invokeStaticMethod<Any>(
+                    packageInstance.rxObservable.just(),
+                    response
+                ) ?: run {
+                    YLog.error("$TAG: rxObservable.just() returned null, cannot wrap response into observable")
+                    return@before
+                }
+                result = observable
             }
         }
     }

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/FeedDownloadModuleHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/FeedDownloadModuleHooker.kt
@@ -1,12 +1,14 @@
 package io.github.twyora.douyinenhancer.hook.feed
 
 import com.highcapable.kavaref.extension.createInstance
+import com.highcapable.yukihookapi.hook.core.YukiMemberHookCreator
 import com.highcapable.yukihookapi.hook.entity.YukiBaseHooker
 import com.highcapable.yukihookapi.hook.log.YLog
 import io.github.twyora.douyinenhancer.config.FastKVConfigManager
 import io.github.twyora.douyinenhancer.config.key.ModuleKey
 import io.github.twyora.douyinenhancer.hook.DouyinPackage
 import io.github.twyora.douyinenhancer.hook.HookOnMainProcess
+import io.github.twyora.douyinenhancer.utils.HookTransaction
 import io.github.twyora.douyinenhancer.utils.getField
 import io.github.twyora.douyinenhancer.utils.invokeMethod
 import io.github.twyora.douyinenhancer.utils.invokeStaticMethod
@@ -24,18 +26,34 @@ object FeedDownloadModuleHooker : YukiBaseHooker() {
         get() = !FastKVConfigManager.module.getBoolean(ModuleKey.DISABLE_VERBOSE_LOGS, false)
 
     override fun onHook() {
-        packageInstance.absPermissionChecker.selfClass?.resolveMethod(
+        val transaction = HookTransaction(TAG)
+
+        transaction.add(::installForceActionStatusNormalHook.name) {
+            installForceActionStatusNormalHook()
+        }
+        transaction.add(::installOverridePrivacyVideoDownloadStatusHook.name) {
+            installOverrideAwemeDownloadStatusHook()
+        }
+        transaction.add(::installOverridePrivacyVideoDownloadStatusHook.name) {
+            installOverridePrivacyVideoDownloadStatusHook()
+        }
+
+        transaction.commit()
+    }
+
+    private fun installForceActionStatusNormalHook(): YukiMemberHookCreator.MemberHookCreator.Result? {
+        return packageInstance.absPermissionChecker.selfClass?.resolveMethod(
             packageInstance.absPermissionChecker.getActionCheckResult()
         )?.hook {
             after {
                 val actionCheckResult = result ?: run {
-                    YLog.warn("$TAG: getActionCheckResult of AbsPermissionChecker returned null, cannot override action status")
+                    YLog.warn("$TAG: action permission check result is null, cannot force action status to allowed, download may be blocked")
                     return@after
                 }
                 val actionStatus = actionCheckResult.getField<Any>(
                     packageInstance.actionCheckResult.actionStatus()
                 ) ?: run {
-                    YLog.warn("$TAG: actionStatus field of ActionCheckResult returned null, cannot read action status")
+                    YLog.warn("$TAG: action status is null, cannot decide whether to force it to allowed")
                     return@after
                 }
 
@@ -45,20 +63,29 @@ object FeedDownloadModuleHooker : YukiBaseHooker() {
                 )
 
                 if (verbose) {
-                    YLog.debug("$TAG: permission check actionStatus is $actionStatus")
+                    YLog.debug("$TAG: action status: $actionStatus (target allowed: $normalStatus)")
                 }
 
                 if (actionStatus != normalStatus) {
-                    YLog.info("$TAG: actionStatus is $actionStatus, override to $normalStatus")
+                    YLog.info("$TAG: forcing action status from $actionStatus to $normalStatus to allow download")
                     actionCheckResult.setField(
                         packageInstance.actionCheckResult.actionStatus(),
                         normalStatus
                     )
                 }
             }
+        }?.result {
+            onConductFailure { _, throwable ->
+                YLog.error("$TAG: failed to hook action permission check, download action may stay blocked", throwable)
+            }
+            onHookingFailure {
+                YLog.error("$TAG: hook failed, action status cannot be forced to allowed, download may be blocked")
+            }
         }
+    }
 
-        packageInstance.galleryShareHelper.selfClass?.resolveMethod(
+    private fun installOverrideAwemeDownloadStatusHook(): YukiMemberHookCreator.MemberHookCreator.Result? {
+        return packageInstance.galleryShareHelper.selfClass?.resolveMethod(
             packageInstance.galleryShareHelper.startDownload()
         )?.hook {
             before {
@@ -68,11 +95,11 @@ object FeedDownloadModuleHooker : YukiBaseHooker() {
                 )
 
                 if (verbose) {
-                    YLog.debug("$TAG: aweme downloadStatus is $downloadStatus")
+                    YLog.debug("$TAG: aweme download status: $downloadStatus")
                 }
 
                 if (downloadStatus != 0) {
-                    YLog.info("$TAG: overriding download status of aweme from $downloadStatus to 0")
+                    YLog.info("$TAG: resetting aweme download status from $downloadStatus to 0 to allow download")
                     aweme.getField<Any>(
                         packageInstance.aweme.status()
                     )?.setField(
@@ -81,14 +108,28 @@ object FeedDownloadModuleHooker : YukiBaseHooker() {
                     )
                 }
             }
+        }?.result {
+            onConductFailure { _, throwable ->
+                YLog.error("$TAG: failed to hook gallery share download, aweme download status may stay restricted", throwable)
+            }
+            onHookingFailure {
+                YLog.error("$TAG: hook failed, aweme download status cannot be reset, download may be blocked")
+            }
         }
+    }
 
-        packageInstance.sharePrivacyVideoApi.selfClass?.resolveMethod(
+    private fun installOverridePrivacyVideoDownloadStatusHook(): YukiMemberHookCreator.MemberHookCreator.Result? {
+        return packageInstance.sharePrivacyVideoApi.selfClass?.resolveMethod(
             packageInstance.sharePrivacyVideoApi.getDownloadStatus()
         )?.hook {
             before {
+                val itemId = args[0] as? String
+                if (verbose) {
+                    YLog.debug("$TAG: privacy video download status query aweme id: $itemId")
+                }
+
                 val response = packageInstance.sharePrivacyVideoApi.privacyVideoResponse.selfClass?.createInstance() ?: run {
-                    YLog.error("$TAG: failed to create privacyVideoResponse, cannot set allowed download status")
+                    YLog.error("$TAG: failed to build the allowed-download response, privacy video download may stay blocked")
                     return@before
                 }
                 response.setField(
@@ -104,10 +145,17 @@ object FeedDownloadModuleHooker : YukiBaseHooker() {
                     packageInstance.rxObservable.just(),
                     response
                 ) ?: run {
-                    YLog.error("$TAG: rxObservable.just() returned null, cannot wrap response into observable")
+                    YLog.error("$TAG: failed to return the allowed-download response, privacy video download may stay blocked")
                     return@before
                 }
                 result = observable
+            }
+        }?.result {
+            onConductFailure { _, throwable ->
+                YLog.error("$TAG: failed to hook privacy video download status, host will not treat it as downloadable", throwable)
+            }
+            onHookingFailure {
+                YLog.error("$TAG: hook failed, privacy video download status cannot be faked, download stays blocked")
             }
         }
     }

--- a/app/src/main/proto/io/github/twyora/douyinenhancer/hook/configs.proto
+++ b/app/src/main/proto/io/github/twyora/douyinenhancer/hook/configs.proto
@@ -166,6 +166,14 @@ message Aweme {
   optional Field images = 13;
   optional Field statistics = 14;
   optional Method get_aid = 15;
+  optional Method get_download_status = 16;
+  optional Field aid = 17;
+  optional Field status = 18;
+}
+
+message AwemeStatus {
+  optional Class class = 1;
+  optional Field download_status = 2;
 }
 
 message Video {
@@ -252,6 +260,46 @@ message MultiImageToMp4Composer {
   optional Field image_path_list = 3;
 }
 
+message AbsPermissionChecker {
+  optional Class class = 1;
+  optional Method get_action_check_result = 2;
+}
+
+message ActionCheckResult {
+  optional Class class = 1;
+  optional Field action_status = 2;
+}
+
+message ActionStatus {
+  optional Class class = 1;
+  optional Method value_of = 2;
+  optional Field grayed = 3;
+  optional Field hidden = 4;
+  optional Field normal = 5;
+}
+
+message GalleryShareHelper {
+  optional Class class = 1;
+  optional Method start_download = 2;
+}
+
+message SharePrivacyVideoApi {
+  optional Class class = 1;
+  optional SharePrivacyVideoResponse privacy_video_response = 2;
+  optional Method getDownloadStatus = 3;
+}
+
+message SharePrivacyVideoResponse {
+  optional Class class = 1;
+  optional Field msg = 2;
+  optional Field status = 3;
+}
+
+message RxObservable {
+  optional Class class = 1;
+  optional Method just = 2;
+}
+
 message HookInfo {
   uint64 last_update_time = 1;
   uint32 module_version_code = 2;
@@ -294,4 +342,11 @@ message HookInfo {
   optional SingleImageToMp4Composer single_image_to_mp4_composer = 39;
   optional MultiImageToMp4Composer multi_image_to_mp4_composer = 40;
   optional DownloadLivePhotoExecutor download_live_photo_executor = 41;
+  optional AbsPermissionChecker abs_permission_checker = 42;
+  optional ActionCheckResult action_check_result = 43;
+  optional ActionStatus action_status = 44;
+  optional GalleryShareHelper gallery_share_helper = 45;
+  optional AwemeStatus aweme_status = 46;
+  optional SharePrivacyVideoApi share_privacy_video_api = 47;
+  optional RxObservable rx_observable = 48;
 }

--- a/app/src/main/proto/io/github/twyora/douyinenhancer/hook/configs.proto
+++ b/app/src/main/proto/io/github/twyora/douyinenhancer/hook/configs.proto
@@ -219,11 +219,6 @@ message ABTestServiceImpl {
   optional Method enableVEAddLiveVideoWaterMark = 3;
 }
 
-message LppDownloadModule {
-  optional Class class = 1;
-  optional Method get_visibility = 2;
-}
-
 message HeifDecoder {
   optional Class class = 1;
   optional Field s_bitmap_factory = 2;
@@ -333,7 +328,6 @@ message HookInfo {
   optional DownloadAction download_action = 29;
   optional ImageUrlStruct image_url_struct = 30;
   optional ABTestServiceImpl ab_test_service_impl = 31;
-  optional LppDownloadModule lpp_download_module = 32;
   optional AwemeStatistics aweme_statistics = 33;
   optional HeifDecoder heif_decoder = 35;
   optional HeifBitmapFactoryImpl heif_bitmap_factory_impl = 36;
@@ -349,4 +343,6 @@ message HookInfo {
   optional AwemeStatus aweme_status = 46;
   optional SharePrivacyVideoApi share_privacy_video_api = 47;
   optional RxObservable rx_observable = 48;
+
+  reserved 32;
 }

--- a/app/src/main/res/values-zh-rCN/values-zh.xml
+++ b/app/src/main/res/values-zh-rCN/values-zh.xml
@@ -15,6 +15,8 @@
     <string name="pref_comment_audio_summary">保存至 Music/douyin/audio 目录</string>
     <string name="pref_feed_video_remove_watermark_title">保存无水印视频</string>
     <string name="pref_feed_video_remove_watermark_summary">保存播放版视频而非特供版水印视频</string>
+    <string name="pref_feed_download_bypass_title">允许保存限制内容</string>
+    <string name="pref_feed_download_bypass_summary">绕过推荐内容保存限制</string>
     <string name="pref_feed_multi_image_remove_watermark_title">保存无水印多图帖</string>
     <string name="pref_feed_multi_image_remove_watermark_summary">去除图片内置水印与边框水印</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,6 +14,8 @@
     <string name="pref_comment_audio_summary">Save to Music/douyin/audio directory</string>
     <string name="pref_feed_video_remove_watermark_title">Save Feed Videos Without Watermark</string>
     <string name="pref_feed_video_remove_watermark_summary">Uses the playback stream instead of the watermarked download-specific version</string>
+    <string name="pref_feed_download_bypass_title">Allow Saving Restricted Feed</string>
+    <string name="pref_feed_download_bypass_summary">Bypass recommended feed save restrictions</string>
     <string name="pref_feed_multi_image_remove_watermark_title">Save Watermark-Free Multi-Image Posts</string>
     <string name="pref_feed_multi_image_remove_watermark_summary">Remove in-image and border watermarks</string>
 

--- a/app/src/main/res/xml/prefs_setting.xml
+++ b/app/src/main/res/xml/prefs_setting.xml
@@ -31,6 +31,12 @@
 
         <SwitchPreference
             android:defaultValue="false"
+            android:key="feed_download_bypass"
+            android:summary="@string/pref_feed_download_bypass_summary"
+            android:title="@string/pref_feed_download_bypass_title" />
+
+        <SwitchPreference
+            android:defaultValue="false"
             android:key="feed_multi_image_remove_watermark"
             android:summary="@string/pref_feed_multi_image_remove_watermark_summary"
             android:title="@string/pref_feed_multi_image_remove_watermark_title" />


### PR DESCRIPTION
## Summary
Bypass recommended-feed save restrictions. The behavior is gated behind a new default-off switch `feed_download_bypass`

## How the bypass works
`FeedDownloadHooker`(renamed from FeedDownloadModuleHooker):
- `AbsPermissionChecker.getActionCheckResult`: force the returned action status to NORMAL, so the download action is no longer blocked
- `GalleryShareHelper.startDownload`: reset the `Aweme` download-status field to 0 when it is non-zero, so the item is treated as downloadable
- `SharePrivacyVideoApi.getDownloadStatus`: return a faked allowed response