### PR TITLE
chore: code cleanup and minor correctness fixes

### DIFF
--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/DouyinPackage.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/DouyinPackage.kt
@@ -12,7 +12,6 @@ import com.highcapable.kavaref.condition.matcher.extension.parameterizedBy
 import com.highcapable.kavaref.condition.matcher.extension.toTypeMatcher
 import com.highcapable.kavaref.condition.type.Modifiers
 import com.highcapable.kavaref.extension.toClass
-import com.highcapable.kavaref.extension.toClassOrNull
 import com.highcapable.yukihookapi.hook.log.YLog
 import io.github.twyora.douyinenhancer.BuildConfig
 import io.github.twyora.douyinenhancer.config.FastKVConfigManager
@@ -1920,7 +1919,7 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
                                     }
                                     add {
                                         descriptor =
-                                            "Lcom/ss/android/ugc/aweme/services/external/ui/IStoryService;->convertImgToMp4(Landroid/content/Context;Landroidx/lifecycle/LifecycleOwner;Ljava/lang/String;Ljava/lang/String;ZJLjava/lang/String;Lcom/ss/android/ugc/aweme/services/external/ui/IStoryService\$OnMuxImgToMp4Callback;)V"
+                                            $$"Lcom/ss/android/ugc/aweme/services/external/ui/IStoryService;->convertImgToMp4(Landroid/content/Context;Landroidx/lifecycle/LifecycleOwner;Ljava/lang/String;Ljava/lang/String;ZJLjava/lang/String;Lcom/ss/android/ugc/aweme/services/external/ui/IStoryService$OnMuxImgToMp4Callback;)V"
                                     }
                                 }
                             }
@@ -2428,7 +2427,7 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
                                 sharePrivacyVideoResponse {
                                     class_ =
                                         class_ {
-                                            name = "com.ss.android.ugc.aweme.feed.share.video.SharePrivacyVideoApi\$PrivacyVideoResponse"
+                                            name = $$"com.ss.android.ugc.aweme.feed.share.video.SharePrivacyVideoApi$PrivacyVideoResponse"
                                         }
                                     msg =
                                         field {

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/comment/CommentAudioHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/comment/CommentAudioHooker.kt
@@ -327,7 +327,7 @@ object CommentAudioHooker : YukiBaseHooker() {
             packageInstance.comment.imageList()
         )
         val imageUrlList = if (existingImageUrlList.isNullOrEmpty()) {
-            val newImageUrlList = listOf<Any?>(
+            val newImageUrlList = listOf(
                 packageInstance.commentImageStruct.selfClass?.getConstructor()?.newInstance()
             )
             comment.setField(

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/comment/CommentAudioHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/comment/CommentAudioHooker.kt
@@ -2,6 +2,7 @@ package io.github.twyora.douyinenhancer.hook.comment
 
 import android.content.Context
 import android.net.Uri
+import com.highcapable.kavaref.extension.createInstance
 import com.highcapable.yukihookapi.hook.core.YukiMemberHookCreator
 import com.highcapable.yukihookapi.hook.entity.YukiBaseHooker
 import com.highcapable.yukihookapi.hook.log.YLog
@@ -328,7 +329,7 @@ object CommentAudioHooker : YukiBaseHooker() {
         )
         val imageUrlList = if (existingImageUrlList.isNullOrEmpty()) {
             val newImageUrlList = listOf(
-                packageInstance.commentImageStruct.selfClass?.getConstructor()?.newInstance()
+                packageInstance.commentImageStruct.selfClass?.createInstance()
             )
             comment.setField(
                 packageInstance.comment.imageList(),
@@ -343,7 +344,7 @@ object CommentAudioHooker : YukiBaseHooker() {
             packageInstance.commentImageStruct.downloadUrl()
         )
         val imageUrlModel = if (existingImageUrlModel == null) {
-            val newImageUrlModel = packageInstance.urlModel.selfClass?.getConstructor()?.newInstance()
+            val newImageUrlModel = packageInstance.urlModel.selfClass?.createInstance()
             imageUrlList.first()?.setField(
                 packageInstance.commentImageStruct.downloadUrl(),
                 newImageUrlModel

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/comment/CommentEmojiHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/comment/CommentEmojiHooker.kt
@@ -9,6 +9,7 @@ import android.net.Uri
 import android.os.Build
 import android.webkit.MimeTypeMap
 import com.highcapable.kavaref.KavaRef.Companion.asResolver
+import com.highcapable.kavaref.extension.createInstance
 import com.highcapable.yukihookapi.hook.core.YukiMemberHookCreator
 import com.highcapable.yukihookapi.hook.entity.YukiBaseHooker
 import com.highcapable.yukihookapi.hook.log.YLog
@@ -268,8 +269,7 @@ object CommentEmojiHooker : YukiBaseHooker() {
                         fileToSave,
                         saveFilePath,
                         DouyinPackage.instance.tokenCert.selfClass
-                            ?.getConstructor(String::class.java)
-                            ?.newInstance("bpea-comment_save_image_to_album")
+                            ?.createInstance("bpea-comment_save_image_to_album")
                     )
 
                 // shows success dialog
@@ -416,9 +416,7 @@ object CommentEmojiHooker : YukiBaseHooker() {
         var imageList = comment.getField<List<*>>(DouyinPackage.instance.comment.imageList())
         if (imageList.isNullOrEmpty()) {
             val newStruct =
-                DouyinPackage.instance.commentImageStruct.selfClass
-                    ?.getConstructor()
-                    ?.newInstance()
+                DouyinPackage.instance.commentImageStruct.selfClass?.createInstance()
             imageList = listOf(newStruct)
             comment.setField(DouyinPackage.instance.comment.imageList(), imageList)
         }
@@ -429,9 +427,7 @@ object CommentEmojiHooker : YukiBaseHooker() {
         )
         if (urlModel == null) {
             urlModel =
-                DouyinPackage.instance.urlModel.selfClass
-                    ?.getConstructor()
-                    ?.newInstance()
+                DouyinPackage.instance.urlModel.selfClass?.createInstance()
             targetStruct?.setField(
                 DouyinPackage.instance.commentImageStruct.downloadUrl(),
                 urlModel

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/comment/CommentEmojiHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/comment/CommentEmojiHooker.kt
@@ -18,7 +18,6 @@ import io.github.twyora.douyinenhancer.config.key.ModuleKey
 import io.github.twyora.douyinenhancer.config.key.SaveKey
 import io.github.twyora.douyinenhancer.hook.DouyinPackage
 import io.github.twyora.douyinenhancer.hook.HookOnMainProcess
-import io.github.twyora.douyinenhancer.hook.emoji
 import io.github.twyora.douyinenhancer.utils.FileTypeDetector
 import io.github.twyora.douyinenhancer.utils.HookTransaction
 import io.github.twyora.douyinenhancer.utils.getField
@@ -139,7 +138,7 @@ object CommentEmojiHooker : YukiBaseHooker() {
                 savedActionItem = actionItem
                 savedComment = comment
 
-                injectEmojiUrls(comment, emojiUrls, prepend = true)
+                injectEmojiUrls(comment, emojiUrls)
 
                 if (verbose) {
                     YLog.debug("$TAG: injected ${emojiUrls.size} emoji url(s) into comment, emoji url(s): $emojiUrls")
@@ -413,7 +412,7 @@ object CommentEmojiHooker : YukiBaseHooker() {
     }
 
     // Writes emoji URLs into comment.imageList[0].downloadUrl.urlList, optionally prepended to existing URLs
-    private fun injectEmojiUrls(comment: Any, emojiUrls: List<String>, prepend: Boolean = true) {
+    private fun injectEmojiUrls(comment: Any, emojiUrls: List<String>) {
         var imageList = comment.getField<List<*>>(DouyinPackage.instance.comment.imageList())
         if (imageList.isNullOrEmpty()) {
             val newStruct =
@@ -439,19 +438,16 @@ object CommentEmojiHooker : YukiBaseHooker() {
             )
         }
 
-        var finalUrls: List<String>? =
-            if (prepend) {
-                val imageUrls = urlModel?.getField<List<String>>(
-                    DouyinPackage.instance.urlModel.urlList()
-                )
-                if (imageUrls.isNullOrEmpty()) {
-                    emojiUrls
-                } else {
-                    emojiUrls + imageUrls
-                }
-            } else {
+        val finalUrls: List<String> = run {
+            val imageUrls = urlModel?.getField<List<String>>(
+                DouyinPackage.instance.urlModel.urlList()
+            )
+            if (imageUrls.isNullOrEmpty()) {
                 emojiUrls
+            } else {
+                emojiUrls + imageUrls
             }
+        }
         urlModel?.setField(DouyinPackage.instance.urlModel.urlList(), finalUrls)
     }
 
@@ -547,11 +543,9 @@ object CommentEmojiHooker : YukiBaseHooker() {
                 // Extract frame
                 var bitmap: Bitmap? = null
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                    try {
+                    runCatching {
                         // Try by index for animated
                         bitmap = retriever.getFrameAtIndex(i)
-                    } catch (e: Exception) {
-                        // Fallback
                     }
                 }
 

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/FeedVideoHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/FeedVideoHooker.kt
@@ -7,7 +7,6 @@ import io.github.twyora.douyinenhancer.config.key.ModuleKey
 import io.github.twyora.douyinenhancer.config.key.SaveKey
 import io.github.twyora.douyinenhancer.hook.DouyinPackage
 import io.github.twyora.douyinenhancer.hook.HookOnMainProcess
-import io.github.twyora.douyinenhancer.utils.getField
 import io.github.twyora.douyinenhancer.utils.invokeMethod
 import io.github.twyora.douyinenhancer.utils.resolveMethod
 

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/settings/SettingsHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/settings/SettingsHooker.kt
@@ -31,7 +31,7 @@ object SettingsHooker : YukiBaseHooker() {
 
     override fun onHook() {
         installModuleSettingsEntryHook()
-        installAboutMeLongClickOpenSettingsHook()
+        installAboutAwemeLongClickOpenSettingsHook()
     }
 
     private fun installModuleSettingsEntryHook(): YukiMemberHookCreator.MemberHookCreator.Result? {
@@ -108,7 +108,7 @@ object SettingsHooker : YukiBaseHooker() {
         }
     }
 
-    private fun installAboutMeLongClickOpenSettingsHook(): YukiMemberHookCreator.MemberHookCreator.Result? {
+    private fun installAboutAwemeLongClickOpenSettingsHook(): YukiMemberHookCreator.MemberHookCreator.Result? {
         return packageInstance.douYinSettingNewVersionActivity.selfClass?.resolveMethod(
             packageInstance.douYinSettingNewVersionActivity.onResume()
         )?.hook {
@@ -125,7 +125,7 @@ object SettingsHooker : YukiBaseHooker() {
                     return@after
                 }
 
-                val aboutMeView = settingsScrollView.findViewWithTag<View?>("about_ame") ?: run {
+                val aboutAwemeView = settingsScrollView.findViewWithTag<View?>("about_ame") ?: run {
                     YLog.error("$TAG: about_ame view not found by tag in settings scroll view")
                     return@after
                 }
@@ -133,7 +133,7 @@ object SettingsHooker : YukiBaseHooker() {
                 if (verbose) {
                     YLog.debug("$TAG: attaching long click listener on about_ame view to open settings dialog")
                 }
-                aboutMeView.setOnLongClickListener {
+                aboutAwemeView.setOnLongClickListener {
                     SettingsDialog.show(activity)
                     true
                 }

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/settings/SettingsHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/settings/SettingsHooker.kt
@@ -1,8 +1,6 @@
 package io.github.twyora.douyinenhancer.hook.settings
 
 import android.app.Activity
-import android.content.Context
-import android.service.voice.VoiceInteractionSession
 import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
@@ -11,7 +9,6 @@ import com.highcapable.yukihookapi.hook.core.YukiMemberHookCreator
 import com.highcapable.yukihookapi.hook.entity.YukiBaseHooker
 import com.highcapable.yukihookapi.hook.factory.injectModuleAppResources
 import com.highcapable.yukihookapi.hook.log.YLog
-import com.highcapable.yukihookapi.hook.type.android.ActivityInfoClass
 import io.github.twyora.douyinenhancer.R
 import io.github.twyora.douyinenhancer.config.FastKVConfigManager
 import io.github.twyora.douyinenhancer.config.key.ModuleKey

--- a/app/src/main/java/io/github/twyora/douyinenhancer/utils/FileTypeDetector.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/utils/FileTypeDetector.kt
@@ -354,5 +354,5 @@ object FileTypeDetector {
         }
     }
 
-    fun detect(filePath: String, headerSize: Int = 32): FileTypeInfo = detect(File(filePath))
+    fun detect(filePath: String, headerSize: Int = 32): FileTypeInfo = detect(File(filePath), headerSize)
 }


### PR DESCRIPTION
Cleanup pass on the hook code plus a correctness fix:

- **fix(settings-hooker)**: rename `aboutMe` to `aboutAweme`
- **refactor**: replace `getConstructor()?.newInstance()` with KavaRef's `createInstance()` extension in CommentAudioHooker and CommentEmojiHooker
- **chore(kotlin)**: resolve Android Studio inspection warnings:
  - remove unused imports
  - drop the unused `prepend` parameter in `injectEmojiUrls`
  - fix `FileTypeDetector.detect(filePath)` not forwarding `headerSize` to the `File` overload