### PR TITLE
refactor: modernize hook entry initialization and make DouyinPackage init explicit

### DIFF
--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/DouyinPackage.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/DouyinPackage.kt
@@ -59,10 +59,6 @@ val Configs.Method.Parameters.valuesListOrNull
         }
 
 class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
-    init {
-        instance = this
-    }
-
     private val hookInfo: Configs.HookInfo =
         run {
             val (result, time) =
@@ -798,6 +794,10 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
 
         @Volatile
         lateinit var instance: DouyinPackage
+
+        fun init(classLoader: ClassLoader, context: Context) {
+            instance = DouyinPackage(classLoader, context)
+        }
 
         private fun readHookInfo(context: Context): Configs.HookInfo {
             val androidId =

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/HookEntry.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/HookEntry.kt
@@ -40,7 +40,7 @@ object HookEntry : IYukiHookXposedInit {
 
                         FastKVConfigManager.init(context)
                         // load cached HookInfo and run hooks when app context is available
-                        DouyinPackage(appClassLoader!!, context)
+                        DouyinPackage.init(appClassLoader!!, context)
 
                         YLog.info(
                             "verbose logging disabled is ${

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/HookEntry.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/HookEntry.kt
@@ -1,9 +1,5 @@
 package io.github.twyora.douyinenhancer.hook
 
-import android.app.Application
-import android.app.Instrumentation
-import android.content.Context
-import com.highcapable.kavaref.KavaRef.Companion.resolve
 import com.highcapable.yukihookapi.YukiHookAPI
 import com.highcapable.yukihookapi.annotation.xposed.InjectYukiHookWithXposed
 import com.highcapable.yukihookapi.hook.factory.encase
@@ -26,21 +22,16 @@ object HookEntry : IYukiHookXposedInit {
     override fun onHook() = encase {
         loadApp(name = "com.ss.android.ugc.aweme") {
             withProcess(mainProcessName) {
-                Instrumentation::class.resolve().firstMethod {
-                    name = "callApplicationOnCreate"
-                    parameters(Application::class)
-                }.hook {
-                    before {
-                        val context = args[0] as? Context ?: return@before
-
+                onAppLifecycle {
+                    onCreate {
                         // hook main process only; skip plugin sub-processes
-                        if (appInfo.sourceDir != context.applicationInfo.sourceDir) {
-                            return@before
+                        if (appInfo.sourceDir != this.applicationInfo.sourceDir) {
+                            return@onCreate
                         }
 
-                        FastKVConfigManager.init(context)
+                        FastKVConfigManager.init(this)
                         // load cached HookInfo and run hooks when app context is available
-                        DouyinPackage.init(appClassLoader!!, context)
+                        DouyinPackage.init(this.classLoader, this)
 
                         YLog.info(
                             "verbose logging disabled is ${


### PR DESCRIPTION
- DouyinPackage: replace the constructor-registered singleton with an explicit init() factory.
- HookEntry: modernize by dropping Instrumentation.callApplicationOnCreate hook in favor of onAppLifecycle { onCreate }.