### PR TITLE
fix: reduce feed download verbose log output on normal status

### DIFF
--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/FeedDownloadHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/FeedDownloadHooker.kt
@@ -71,7 +71,7 @@ object FeedDownloadHooker : YukiBaseHooker() {
                     packageInstance.actionStatus.normal().name
                 )
 
-                if (verbose) {
+                if (verbose && actionStatus != normalStatus) {
                     YLog.debug("$TAG: action status: $actionStatus (target allowed: $normalStatus)")
                 }
 


### PR DESCRIPTION
Narrow the feed-download debug log so it only prints under verbose when the action status is not normal, instead of logging on every normal status