### PR TITLE
refactor(feed): clean up listen-aweme hooker

### DIFF
--- a/PM.md
+++ b/PM.md
@@ -2,8 +2,6 @@
 
 ## In Progress
 
-- [ ] Remove copyright restriction of Douyin Audio Mode
-
 ## TODO
 
 - [ ] Save favorited emojis to album
@@ -22,6 +20,7 @@
 
 - [x] ~~More reliable way to inject module settings into the host app's settings page~~ Long-press
   "About Aweme" to open module settings dialog
+- [x] Remove copyright restriction of Douyin Audio Mode
 - [x] Adapt module to Douyin v38.8.0
 - [x] Add dark mode support for module settings page
 - [x] Download restricted content

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/ListenAwemeFeedHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/ListenAwemeFeedHooker.kt
@@ -29,7 +29,6 @@ object ListenAwemeFeedHooker : YukiBaseHooker() {
             return
         }
         installBypassListenAwemeFilterHook()
-        // installForceListenAwemeFeedItemListStatusOkHook()
     }
 
     private fun installBypassListenAwemeFilterHook(): YukiMemberHookCreator.MemberHookCreator.Result? =
@@ -54,32 +53,4 @@ object ListenAwemeFeedHooker : YukiBaseHooker() {
                 YLog.error("$TAG: hook failed, listen aweme filter cannot be bypassed, some aweme may be filtered out")
             }
         }
-
-    // forcing statusCode to 1 blocks other feeds from loading and prevents favorites from loading
-//    private fun installForceListenAwemeFeedItemListStatusOkHook(): YukiMemberHookCreator.MemberHookCreator.Result? {
-//        // com.ss.android.ugc.aweme.feed.model.FeedItemList->getStatusCodeP()I
-//        return packageInstance.feedItemList.selfClass?.resolveMethod(
-//            packageInstance.feedItemList.getStatusCodeP()
-//        )?.hook {
-//            before {
-//                val statusCode = instance.getField<Int>(
-//                    packageInstance.feedItemList.statusCode()
-//                )
-//                if (statusCode == 0) {
-//                    // I don't know why statusCode being 0 represents an invalid status
-//                    if (verbose) {
-//                        YLog.debug("$TAG: feed item list status invalid ($statusCode), marking valid to let listen aweme feed load")
-//                    }
-//                    result = 1
-//                }
-//            }
-//        }?.result {
-//            onConductFailure { _, throwable ->
-//                YLog.error("$TAG: failed to fix feed item list status, listen aweme feed may fail to load", throwable)
-//            }
-//            onHookingFailure {
-//                YLog.error("$TAG: hook failed, feed item list status cannot be fixed, listen aweme feed may fail to load")
-//            }
-//        }
-//    }
 }

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/ListenAwemeFilterHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/ListenAwemeFilterHooker.kt
@@ -12,7 +12,7 @@ import io.github.twyora.douyinenhancer.utils.getField
 import io.github.twyora.douyinenhancer.utils.resolveMethod
 
 @HookOnMainProcess
-object ListenAwemeFeedHooker : YukiBaseHooker() {
+object ListenAwemeFilterHooker : YukiBaseHooker() {
     private val TAG = this::class.simpleName
 
     private val packageInstance


### PR DESCRIPTION
- Rename the listen-aweme hooker to `ListenAwemeFilterHooker` to match its actual responsibility
- Remove the long-disabled force-status hook and its commented-out call site; forcing statusCode also breaks other feeds and favorites loading
- Mark "Remove copyright restriction of Douyin Audio Mode" as done