### PR TITLE
feat: adapt feed download / watermark-free / multi-image / double-tap digg for Douyin 39.6.0/39.9.0

### DIFF
--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/DouyinPackage.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/DouyinPackage.kt
@@ -910,21 +910,63 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
                         runCatching {
                             val cmtImgClsName =
                                 "com.ss.android.ugc.aweme.comment.model.CommentImageStruct"
-                            val originUrlFieldName = "originUrl"
-                            val downloadUrlFieldName = "downloadUrl"
+                            val urlModelTypeName =
+                                "com.ss.android.ugc.aweme.base.model.UrlModel"
+                            // 37.6/38.8 and earlier: field names not obfuscated, match by name.
+                            var originUrlFieldName = "originUrl"
+                            var downloadUrlFieldName = "downloadUrl"
                             val getDownloadUrlMethodData =
                                 bridge
                                     .findMethod {
                                         matcher {
                                             declaredClass =
-                                                "com.ss.android.ugc.aweme.comment.model.CommentImageStruct"
-                                            returnType = "com.ss.android.ugc.aweme.base.model.UrlModel"
+                                                cmtImgClsName
+                                            returnType = urlModelTypeName
                                             paramCount = 0
                                             addUsingField {
                                                 name = "downloadUrl"
                                             }
                                         }
-                                    }.singleOrNull() ?: run {
+                                    }.singleOrNull()
+                                    ?: run {
+                                        // 39.6+ fallback: all fields obfuscated (a/b/d/e/f/g/h/i).
+                                        // Parcel slot order = source declaration order = R8 rename
+                                        // order (verified against 38.8, confirmed identical on 39.9.0):
+                                        //   slot 1 = originUrl  (39.6: a)
+                                        //   slot 5 = downloadUrl (39.6: f)
+                                        val urlModelFields =
+                                            cmtImgClsName
+                                                .toClass(hostAppClassLoader)
+                                                .declaredFields
+                                                .filter {
+                                                    it.type.name == urlModelTypeName &&
+                                                        !Modifier.isTransient(it.modifiers) &&
+                                                        !Modifier.isStatic(it.modifiers)
+                                                }
+                                        if (urlModelFields.size < 5) {
+                                            YLog.error(
+                                                "$TAG: CommentImageStruct UrlModel fields too few for fallback: ${urlModelFields.map { it.name }}"
+                                            )
+                                            return@commentImageStruct
+                                        }
+                                        originUrlFieldName = urlModelFields[0].name
+                                        downloadUrlFieldName = urlModelFields[4].name
+                                        YLog.info(
+                                            "$TAG: CommentImageStruct obfuscated field fallback: originUrl=$originUrlFieldName downloadUrl=$downloadUrlFieldName"
+                                        )
+                                        bridge
+                                            .findMethod {
+                                                matcher {
+                                                    declaredClass =
+                                                        cmtImgClsName
+                                                    returnType = urlModelTypeName
+                                                    paramCount = 0
+                                                    addUsingField {
+                                                        name = downloadUrlFieldName
+                                                    }
+                                                }
+                                            }.singleOrNull()
+                                    } ?: run {
                                     YLog.error(
                                         "$TAG: unable to populate ${this::class.java.enclosingClass?.simpleName} config, possibly due to unfound obfuscated methods"
                                     )
@@ -2153,13 +2195,24 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
 
                 downloadAction = downloadAction {
                     runCatching {
+                        // 39.6.0+: DownloadAction class name is obfuscated (X.1Vkh on 39.6.0,
+                        // X.1DM8 on 39.9.0). Match by stable features instead of name suffix:
+                        // implements SheetAction (unobfuscated interface) + downloadImage string.
                         val downloadActionClassData = bridge.findClass {
                             matcher {
-                                className("DownloadAction", StringMatchType.EndsWith)
+                                addInterface("com.ss.android.ugc.aweme.sharer.ui.SheetAction", StringMatchType.Equals, false)
+                                usingStrings {
+                                    add("downloadImage")
+                                }
                             }
-                        }.singleOrNull { classData ->
-                            classData.simpleName == "DownloadAction"
-                        }
+                        }.singleOrNull()
+                            ?: bridge.findClass {
+                                matcher {
+                                    className("DownloadAction", StringMatchType.EndsWith)
+                                }
+                            }.singleOrNull { classData ->
+                                classData.simpleName == "DownloadAction"
+                            }
                         val startDownloadMethodData = downloadActionClassData?.let {
                             bridge.findMethod {
                                 searchClasses = listOf(it)
@@ -2449,6 +2502,23 @@ class DouyinPackage(private val classLoader: ClassLoader, context: Context) {
                                 }
                             }
                         }.singleOrNull()
+                            // 39.6.0+: BgPlayWithHaveCopyrightConfig was removed (renamed /
+                            // relocated), breaking the invokeMethods anchor. Fall back to the
+                            // anchor-less rule — verified unique across 37.6/38.8/39.6: only
+                            // the LIZJ(Aweme,String)Z holder matches PUBLIC/FINAL + boolean +
+                            // (Aweme,String) + listen_video_status; other referrers are fields
+                            // or methods with mismatched params.
+                            ?: bridge.findMethod {
+                                matcher {
+                                    modifiers = Modifier.PUBLIC or Modifier.FINAL
+                                    returnType = "boolean"
+                                    params {
+                                        add("com.ss.android.ugc.aweme.feed.model.Aweme")
+                                        add("java.lang.String")
+                                    }
+                                    addUsingString("listen_video_status")
+                                }
+                            }.singleOrNull()
 
                         if (acceptMethodData == null) {
                             YLog.error(

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/FeedDoubleTapDiggHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/FeedDoubleTapDiggHooker.kt
@@ -1,5 +1,6 @@
 package io.github.twyora.douyinenhancer.hook.feed
 
+import com.highcapable.kavaref.extension.toClassOrNull
 import com.highcapable.yukihookapi.hook.entity.YukiBaseHooker
 import com.highcapable.yukihookapi.hook.log.YLog
 import io.github.twyora.douyinenhancer.config.FastKVConfigManager
@@ -27,12 +28,22 @@ object FeedDoubleTapDiggHooker : YukiBaseHooker() {
             return
         }
 
+        hookPanelDoubleClick()
+        hookViewHolderDoubleClick()
+        hookDiggPresenterDoubleClick()
+        hookDiggLayoutHeartAnimation()
+    }
+
+    /**
+     * Legacy 37.6/38.8 panel entry; method removed on 39.6.0+ (resolve fails safely).
+     */
+    private fun hookPanelDoubleClick() {
         packageInstance.baseListFragmentPanel.selfClass?.resolveMethod(
             packageInstance.baseListFragmentPanel.handleDoubleClick()
         )?.hook {
             before {
                 if (verbose) {
-                    YLog.debug("$TAG: disabling double-tap digg")
+                    YLog.debug("$TAG: disabling double-tap digg (panel)")
                 }
                 resultNull()
             }
@@ -43,6 +54,107 @@ object FeedDoubleTapDiggHooker : YukiBaseHooker() {
             onHookingFailure {
                 YLog.error("$TAG: hook failed, double-tap action cannot be intercepted, double-tap digg may stay enabled")
             }
+        }
+    }
+
+    /**
+     * The double-tap gesture publishes through IFeedViewHolder.handleDoubleClick(Aweme)
+     * implementers (VideoViewHolder / FeedImageViewHolder), which is the request
+     * publisher — blocking it here stops the digg request before it reaches the
+     * presenter. Class names and the interface method name are preserved across
+     * 37.6/38.8/39.6/39.9, so this is pure reflection (no DexKit needed).
+     */
+    private fun hookViewHolderDoubleClick() {
+        val holders = listOf(
+            "com.ss.android.ugc.aweme.feed.adapter.VideoViewHolder" to "VideoViewHolder",
+            "com.ss.android.ugc.aweme.feed.adapter.FeedImageViewHolder" to "FeedImageViewHolder",
+        )
+        for ((holderName, holderLabel) in holders) {
+            val holderClass = holderName.toClassOrNull(appClassLoader) ?: continue
+            val method = holderClass.declaredMethods.firstOrNull {
+                it.name == "handleDoubleClick" &&
+                    it.parameterTypes.size == 1 &&
+                    it.parameterTypes[0].name == "com.ss.android.ugc.aweme.feed.model.Aweme"
+            } ?: continue
+            method.hook {
+                before {
+                    if (verbose) {
+                        YLog.debug("$TAG: disabling double-tap digg via $holderLabel")
+                    }
+                    resultNull()
+                }
+            }
+        }
+    }
+
+    /**
+     * The real double-tap digg executor is FeedDiggPresenter (class name preserved
+     * across versions). Its (Aweme, String) method is the final digg request entry,
+     * called with tag "click_double_like" from the double-tap runnable. Blocking it
+     * at the request layer leaves the right-side digg button working (tag "click_like").
+     */
+    private fun hookDiggPresenterDoubleClick() {
+        val presenterClass =
+            "com.ss.android.ugc.aweme.feed.quick.presenter.FeedDiggPresenter".toClassOrNull(appClassLoader)
+                ?: run {
+                    YLog.warn("$TAG: FeedDiggPresenter not found, skip request hook")
+                    return
+                }
+        var hooked = 0
+        for (method in presenterClass.declaredMethods) {
+            val types = method.parameterTypes
+            if (types.size != 2) continue
+            if (types[0].name != "com.ss.android.ugc.aweme.feed.model.Aweme") continue
+            if (types[1] != String::class.java) continue
+            method.hook {
+                before {
+                    val tag = args.getOrNull(1) as? String
+                    if (tag == "click_double_like") {
+                        if (verbose) {
+                            YLog.debug("$TAG: blocking FeedDiggPresenter.${method.name}(click_double_like)")
+                        }
+                        resultNull()
+                    }
+                }
+            }
+            hooked++
+        }
+        YLog.info("$TAG: hooked $hooked FeedDiggPresenter (Aweme,String) methods")
+    }
+
+    /**
+     * DiggLayout spawns the floating heart ImageViews at (x,y).
+     * Match by signature (FF)V so it works across method renames:
+     * LIZJ(FF)V on 39.6.0, LIZIZ(FF)V on 37.6/38.8.
+     */
+    private fun hookDiggLayoutHeartAnimation() {
+        val diggLayoutClass =
+            "com.ss.android.ugc.aweme.common.widget.DiggLayout".toClassOrNull(appClassLoader)
+                ?: run {
+                    YLog.warn("$TAG: DiggLayout not found, skip heart animation hook")
+                    return
+                }
+        val floatType = Float::class.javaPrimitiveType
+        val methods = diggLayoutClass.declaredMethods.filter { method ->
+            method.parameterTypes.size == 2 &&
+                method.parameterTypes[0] == floatType &&
+                method.parameterTypes[1] == floatType &&
+                method.returnType == Void.TYPE
+        }
+        if (methods.isEmpty()) {
+            YLog.warn("$TAG: no DiggLayout (FF)V method found")
+            return
+        }
+        for (method in methods) {
+            method.hook {
+                before {
+                    if (verbose) {
+                        YLog.debug("$TAG: blocking DiggLayout.${method.name}(FF) heart animation")
+                    }
+                    resultNull()
+                }
+            }
+            YLog.info("$TAG: hooked DiggLayout.${method.name}(FF)V")
         }
     }
 }

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/FeedDownloadHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/FeedDownloadHooker.kt
@@ -1,6 +1,7 @@
 package io.github.twyora.douyinenhancer.hook.feed
 
 import com.highcapable.kavaref.extension.createInstance
+import com.highcapable.kavaref.extension.toClassOrNull
 import com.highcapable.yukihookapi.hook.core.YukiMemberHookCreator
 import com.highcapable.yukihookapi.hook.entity.YukiBaseHooker
 import com.highcapable.yukihookapi.hook.log.YLog
@@ -9,16 +10,22 @@ import io.github.twyora.douyinenhancer.config.key.ModuleKey
 import io.github.twyora.douyinenhancer.config.key.SaveKey
 import io.github.twyora.douyinenhancer.hook.DouyinPackage
 import io.github.twyora.douyinenhancer.hook.HookOnMainProcess
+import io.github.twyora.douyinenhancer.utils.Field
 import io.github.twyora.douyinenhancer.utils.HookTransaction
 import io.github.twyora.douyinenhancer.utils.getField
 import io.github.twyora.douyinenhancer.utils.invokeMethod
 import io.github.twyora.douyinenhancer.utils.invokeStaticMethod
 import io.github.twyora.douyinenhancer.utils.resolveMethod
 import io.github.twyora.douyinenhancer.utils.setField
+import java.lang.reflect.Modifier
 
 @HookOnMainProcess
 object FeedDownloadHooker : YukiBaseHooker() {
     private val TAG = this::class.simpleName
+
+    private const val GALLERY_SHARE_HELPER =
+        "com.ss.android.ugc.aweme.share.video.GalleryShareHelper"
+    private const val AWEME_CLASS = "com.ss.android.ugc.aweme.feed.model.Aweme"
 
     private val packageInstance
         get() = DouyinPackage.instance
@@ -43,6 +50,27 @@ object FeedDownloadHooker : YukiBaseHooker() {
         }
         transaction.add(::installOverridePrivacyVideoDownloadStatusHook.name) {
             installOverridePrivacyVideoDownloadStatusHook()
+        }
+
+        if (packageInstance.hostVersionCode() >= 390601) {
+            // 39.6.0+: AbsPermissionChecker / ActionStatus are gone and the download
+            // pipeline was rewritten (DownloadAction -> LX/1deN). The legacy hooks
+            // above silently no-op. Install the replacement chain below. All anchors
+            // are stable class names / signatures (GalleryShareHelper, Aweme,
+            // UrlModel.getUrlList, MultiStateDownloadViewHolder, DownloadAction.enable)
+            // so they survive the 39.9.0 obfuscation reshuffle (X.1Vkh -> X.1DM8).
+            installAwemeGetDownloadStatusHook()
+            installMultiStateDownloadHook()
+            installLongPressSaveItemHook()
+            installNeedDownloadActionForceHook()
+            installShareFunctionAdapterHook()
+            installPermissionResultForceNormalHook()
+            installClearDownloadFailInfoHook()
+            installBlockedCheckBypassHook()
+            installUrlListChokePointHook()
+            installDownloadActionEnableHook()
+            installConsumerPermissionForceNormalHook()
+            installDownloadAddrOverrideHook()
         }
 
         transaction.commit()
@@ -161,6 +189,799 @@ object FeedDownloadHooker : YukiBaseHooker() {
             }
             onHookingFailure {
                 YLog.error("$TAG: hook failed, privacy video download status cannot be faked, download stays blocked")
+            }
+        }
+    }
+
+    /**
+     * 39.6.0+: AwemeStatus fields are obfuscated (downloadStatus -> single-letter),
+     * so the field-write path in [installOverrideAwemeDownloadStatusHook] silently
+     * no-ops. Hooking the getter directly is version-agnostic: Aweme.getDownloadStatus()
+     * is kept across 39.6.0/39.9.0, and forcing it to 0 covers every read site.
+     */
+    private fun installAwemeGetDownloadStatusHook() {
+        packageInstance.aweme.selfClass?.resolveMethod(
+            packageInstance.aweme.getDownloadStatus()
+        )?.hook {
+            after {
+                result = 0
+            }
+        } ?: YLog.error("$TAG: Aweme.getDownloadStatus not resolved")
+    }
+
+    /**
+     * 39.6.0+/39.9.0: share-panel 保存本地 greys forbidden-download awemes.
+     *
+     * Real grey path (smali, SocialActionsAdapter.onBindViewHolder):
+     *   v7 = panelState.LIZLLL  (ShareService.LJJJJL can-download)
+     *   v5 = panelState.LJFF    (AwemeControl.b && !teenMode)
+     *   if (!(v7 && v5)) icon/label alpha = 0.34f  // greys the button
+     * O5() is only a click-side grey-disable (f GONE / g VISIBLE / b alpha0) and
+     * often never runs when just opening the panel — so ctor/O5-only force is not enough.
+     *
+     * Fix layers (stable class names, no X.* hardcodes):
+     * 1) MultiStateDownloadViewHolder ctor after — baseline force-enabled
+     * 2) O5-like zero-arg void — skip click-side grey path
+     * 3) SocialActionsAdapter.onBindViewHolder after — force icon/label alpha=1
+     *    every time the row is bound (covers the real panel-open grey path)
+     */
+    private fun installMultiStateDownloadHook() {
+        val holderClassName =
+            "com.ss.android.ugc.aweme.share.socialpanel.viewholder.MultiStateDownloadViewHolder"
+        val clazz = holderClassName.toClassOrNull(appClassLoader) ?: run {
+            YLog.error("$TAG: MultiStateDownloadViewHolder not found")
+            return
+        }
+        YLog.info("$TAG: installing MultiStateDownloadViewHolder grey-bypass hooks")
+        clazz.declaredConstructors.firstOrNull()?.hook {
+            after {
+                val forced = forceAllViewFieldsEnabled(instance)
+                YLog.info("$TAG: MultiStateDownloadViewHolder ctor force-enabled ($forced views)")
+            }
+        }
+        // 39.9.0 O5()V is the only non-static zero-arg void instance method on this class.
+        val greyMethods =
+            clazz.declaredMethods.filter {
+                !Modifier.isStatic(it.modifiers) &&
+                    it.returnType == Void.TYPE &&
+                    it.parameterTypes.isEmpty() &&
+                    !it.name.startsWith("access$")
+            }
+        if (greyMethods.isEmpty()) {
+            YLog.warn("$TAG: MultiStateDownloadViewHolder O5-like method not found")
+        }
+        greyMethods.forEach { method ->
+            method.hook {
+                before {
+                    resultNull()
+                    val forced = forceAllViewFieldsEnabled(instance)
+                    YLog.info(
+                        "$TAG: blocked MultiStateDownloadViewHolder.${method.name}() " +
+                            "grey-disable (forced $forced views)"
+                    )
+                }
+            }
+        }
+
+        // Bind-time alpha grey (primary path for panel open). 39.9.0 has TWO
+        // social-panel adapters that both bind download rows:
+        //   SocialActionsPanelContentAdapter (main share-panel content grid)
+        //   SocialActionsAdapter (action-bar row, MultiStateDownloadViewHolder)
+        // Hook both — force every bound row's View fields bright.
+        val adapterClasses = listOf(
+            "com.ss.android.ugc.aweme.share.socialpanel.adapter.SocialActionsPanelContentAdapter",
+            "com.ss.android.ugc.aweme.share.socialpanel.adapter.SocialActionsAdapter"
+        )
+        for (adapterName in adapterClasses) {
+            val adapterClass = adapterName.toClassOrNull(appClassLoader) ?: continue
+            val bindMethod =
+                adapterClass.declaredMethods.firstOrNull {
+                    it.name.contains("onBindViewHolder") && it.parameterTypes.size == 2
+                } ?: run {
+                    YLog.error("$TAG: $adapterName.onBindViewHolder not found")
+                    continue
+                }
+            bindMethod.hook {
+                after {
+                    val holder = args.getOrNull(0) ?: return@after
+                    val forced = forceAllViewFieldsEnabled(holder)
+                    if (forced > 0) {
+                        YLog.info(
+                            "$TAG: ${adapterName.substringAfterLast('.')}.bind " +
+                                "${holder.javaClass.simpleName} force-enabled ($forced views)"
+                        )
+                    }
+                }
+            }
+            YLog.info("$TAG: hooked $adapterName.onBindViewHolder")
+        }
+    }
+
+    /**
+     * 39.9.0 分享面板功能按钮真实渲染 adapter：
+     *   im/share/aweme/only/sharepanel/ui/ShareFunctionAdapter
+     * 「保存本地」= DownloadFunction。onBindViewHolder 可用分支条件：
+     *   holder.a(LX/1DCl).LJJI == true 且 X.1DTv.LJ(...)==true
+     * 条件不满足 → 只画灰图标、不绑 OnClickListener → 点了无反应。
+     * before-hook：在原生绑定逻辑跑之前把 LJJI 设 true，让原生代码自己绑点击；
+     * after-hook：强制 alpha=1 去掉灰色。未混淆稳定类。
+     */
+    private fun installShareFunctionAdapterHook() {
+        val clazz =
+            "com.ss.android.ugc.aweme.im.share.aweme.only.sharepanel.ui.ShareFunctionAdapter"
+                .toClassOrNull(appClassLoader) ?: run {
+                YLog.error("$TAG: ShareFunctionAdapter not found")
+                return
+            }
+        val bindMethod = clazz.declaredMethods.firstOrNull {
+            it.name.contains("onBindViewHolder") && it.parameterTypes.size == 2
+        } ?: run {
+            YLog.error("$TAG: ShareFunctionAdapter.onBindViewHolder not found")
+            return
+        }
+        // BEFORE: force LJJI=true so the native "available" branch runs.
+        // AFTER: force alpha + manually bind click on the SaveLocalFunction row.
+        // The native available branch also requires X.1DTv.LJ==true (removed —
+        // it broke the friend row), so the click listener is never bound natively;
+        // we attach our own listener that calls SaveLocalFunction.LJIILIIL().
+        bindMethod.hook {
+            before {
+                val holder = args.getOrNull(0) ?: return@before
+                forceSaveAvailableFlag(holder)
+            }
+            after {
+                val holder = args.getOrNull(0) ?: return@after
+                val forced = forceAllViewFieldsEnabled(holder)
+                if (forced > 0 && verbose) {
+                    YLog.info(
+                        "$TAG: ShareFunctionAdapter.bind ${holder.javaClass.simpleName} " +
+                            "force-enabled ($forced views)"
+                    )
+                }
+                bindSaveLocalClick(instance, holder, args.getOrNull(1))
+            }
+        }
+        YLog.info("$TAG: hooked ShareFunctionAdapter.onBindViewHolder")
+    }
+
+    /** Lazily resolve the download function with the host's own class loader.
+     *  Runtime log proved the 保存本地 button on 39.9.0 is DownloadFunction,
+     *  not SaveLocalFunction (which never appears in the bound function list). */
+    private var saveLocalClassCache: Class<*>? = null
+    private val boundFunctionTypes = mutableSetOf<String>()
+    private fun resolveSaveLocalFunctionClass(host: Any): Class<*>? {
+        saveLocalClassCache?.let { return it }
+        val cl = host.javaClass.classLoader ?: return null
+        val c = runCatching {
+            cl.loadClass("com.ss.android.ugc.aweme.im.share.aweme.only.sharepanel.function.DownloadFunction")
+        }.getOrNull()
+        if (c != null) saveLocalClassCache = c
+        else YLog.warn("$TAG: DownloadFunction class not loadable via host loader")
+        return c
+    }
+
+    /**
+     * On the row whose bound IShareFunction is a SaveLocalFunction, attach our own
+     * click listener that invokes LJIILIIL(). Every failure path logs a reason.
+     */
+    private fun bindSaveLocalClick(adapter: Any, holder: Any, position: Any?) {
+        val clazz = resolveSaveLocalFunctionClass(holder) ?: return
+        runCatching {
+            val pos = position as? Int
+            if (pos == null) {
+                YLog.warn("$TAG: bindSaveLocalClick: position arg is ${position?.javaClass}")
+                return
+            }
+            val func = getBoundShareFunction(adapter, pos)
+            if (func == null) {
+                YLog.warn("$TAG: bindSaveLocalClick: no function resolved at pos $pos")
+                return
+            }
+            val funcName = func.javaClass.name
+            if (boundFunctionTypes.add(funcName)) {
+                YLog.info("$TAG: bindSaveLocalClick: function class seen: $funcName")
+            }
+            if (!clazz.isInstance(func)) {
+                // not the save row — expected for most rows, stay quiet
+                return
+            }
+            val itemViewField = findFieldByName(holder, "itemView")
+            if (itemViewField == null) {
+                YLog.warn("$TAG: bindSaveLocalClick: itemView field not found on ${holder.javaClass.name}")
+                return
+            }
+            itemViewField.isAccessible = true
+            val itemView = itemViewField.get(holder) as? android.view.View
+            if (itemView == null) {
+                YLog.warn("$TAG: bindSaveLocalClick: itemView is null at pos $pos")
+                return
+            }
+            YLog.info(
+                "$TAG: bindSaveLocalClick: pos $pos itemView=${itemView.javaClass.name} " +
+                    "clickable=${itemView.isClickable} hasListener=${itemView.hasOnClickListeners()}"
+            )
+            // Diagnostic touch listener: fires before click dispatch so we can tell
+            // whether touch events reach this view at all.
+            itemView.setOnTouchListener { v, ev ->
+                if (ev.actionMasked == android.view.MotionEvent.ACTION_DOWN) {
+                    YLog.info("$TAG: DownloadFunction row touched (view=${v.javaClass.simpleName})")
+                }
+                false // don't consume — let normal click dispatch continue
+            }
+            val lastClick = longArrayOf(0)
+            val clickListener = android.view.View.OnClickListener {
+                val now = System.currentTimeMillis()
+                if (now - lastClick[0] < 800) return@OnClickListener
+                lastClick[0] = now
+                YLog.info("$TAG: DownloadFunction click intercepted")
+                runCatching {
+                    val m = clazz.getMethod("LJIILIIL")
+                    val r = m.invoke(func)
+                    YLog.info("$TAG: DownloadFunction.LJIILIIL() -> $r")
+                }.onFailure {
+                    YLog.error("$TAG: DownloadFunction click failed: $it")
+                }
+            }
+            // Bind on the whole row subtree so no matter which child receives the
+            // touch, the action fires (itemView itself may only be a container).
+            bindClickRecursive(itemView, clickListener)
+            YLog.info("$TAG: bound manual click on DownloadFunction row (pos $pos)")
+        }.onFailure {
+            YLog.warn("$TAG: bindSaveLocalClick failed: $it")
+        }
+    }
+
+    private fun bindClickRecursive(root: android.view.View, listener: android.view.View.OnClickListener) {
+        root.setOnClickListener(listener)
+        if (root is android.view.ViewGroup) {
+            for (i in 0 until root.childCount) {
+                bindClickRecursive(root.getChildAt(i), listener)
+            }
+        }
+    }
+
+    /**
+     * Get the IShareFunction bound at [position] from the adapter's item list.
+     * adapter.f = List<LX/1DU0>, LX/1DU0.LIZ = IShareFunction.
+     */
+    private fun getBoundShareFunction(adapter: Any?, position: Any?): Any? {
+        val pos = position as? Int ?: return null
+        val listField = findFieldByName(adapter ?: return null, "f") ?: return null
+        return runCatching {
+            listField.isAccessible = true
+            val list = listField.get(adapter) as? List<*> ?: return null
+            val item = list.getOrNull(pos) ?: return null
+            val funcField = findFieldByName(item, "LIZ") ?: return null
+            funcField.isAccessible = true
+            funcField.get(item)
+        }.getOrNull()
+    }
+
+    /**
+     * Locate holder.a (LX/1DCl) and set its boolean "save available" gate to true.
+     * The gate field is LJJI in the 39.9.0 APK.
+     */
+    private fun forceSaveAvailableFlag(holder: Any) {
+        runCatching {
+            // 1) find the X.1DCl field on the holder (by type, fallback by name "a")
+            val dclField = findFieldByType(holder, "X.1DCl") ?: findFieldByName(holder, "a")
+            if (dclField == null) {
+                YLog.warn("$TAG: holder(${holder.javaClass.name}) has no X.1DCl field")
+                return
+            }
+            dclField.isAccessible = true
+            val dclObj = dclField.get(holder)
+            if (dclObj == null) {
+                YLog.warn("$TAG: holder.a (X.1DCl) value is null at bind time")
+                return
+            }
+            // 2) find the LJJI boolean gate on the X.1DCl instance
+            val gate = findFieldByName(dclObj, "LJJI")
+            if (gate == null) {
+                YLog.warn("$TAG: LJJI not found on ${dclObj.javaClass.name}")
+                return
+            }
+            gate.isAccessible = true
+            if (!gate.getBoolean(dclObj)) {
+                gate.setBoolean(dclObj, true)
+                YLog.info("$TAG: ShareFunctionAdapter LJJI forced true (save click enabled)")
+            }
+        }.onFailure {
+            YLog.error("$TAG: forceSaveAvailableFlag failed: ${it.javaClass.simpleName} ${it.message}")
+        }
+    }
+
+    /** Find first field (own + superclasses) whose type name matches [typeName].
+     *  typeName is a Java-style class name (dots), e.g. "X.1DCl". */
+    private fun findFieldByType(obj: Any, typeName: String): java.lang.reflect.Field? {
+        var clz: Class<*>? = obj.javaClass
+        while (clz != null && clz != Any::class.java) {
+            for (field in clz.declaredFields) {
+                val t = field.type.name
+                if (t == typeName) return field
+            }
+            clz = clz.superclass
+        }
+        return null
+    }
+
+    /** Find first field (own + superclasses) with the exact [name]. */
+    private fun findFieldByName(obj: Any, name: String): java.lang.reflect.Field? {
+        var clz: Class<*>? = obj.javaClass
+        while (clz != null && clz != Any::class.java) {
+            for (field in clz.declaredFields) {
+                if (field.name == name) return field
+            }
+            clz = clz.superclass
+        }
+        return null
+    }
+
+    /**
+     * 39.9.0 失败视频（作者关闭下载）的根因：下载执行器 UGFiles 保存链读
+     *   aweme.videoControl.downloadInfo.failInfo.reason（=「作者已关闭下载功能」）
+     * 来决定是否中止保存。外层权限 hook（LIZLLL→NORMAL）已让下载启动，但执行器
+     * 内部直接读视频元数据。修复：hook LX/1DM8.execute()（DownloadAction）before，
+     * 反射清空 this.b(Aweme).videoControl.downloadInfo.failInfo.reason，
+     * 让执行器认为可下载。字段全部未混淆（downloadInfo/failInfo/reason）。
+     */
+    private fun installClearDownloadFailInfoHook() {
+        val clazz = "X.1DM8".toClassOrNull(appClassLoader) ?: run {
+            YLog.error("$TAG: X.1DM8 (DownloadAction) not found")
+            return
+        }
+        clazz.declaredMethods
+            .filter {
+                it.name == "execute" && it.parameterTypes.size == 2 &&
+                    it.parameterTypes[1].name.contains("SharePackage")
+            }
+            .forEach { method ->
+                method.hook {
+                    before {
+                        runCatching {
+                            val awemeField = findFieldByName(instance, "b") ?: return@runCatching
+                            awemeField.isAccessible = true
+                            val aweme = awemeField.get(instance) ?: return@runCatching
+                            clearFailInfoReason(aweme)
+                        }
+                    }
+                }
+            }
+        YLog.info("$TAG: installed LX/1DM8.execute failInfo-clear hook")
+    }
+
+    /** Rewrite aweme download-blocked markers so downloader proceeds.
+     *  Runtime correlation proved the real gate:
+     *    video.K == true  → 作者关闭下载 → 下载失败
+     *    video.K == false → 全部下载成功
+     *  Set video.K=false and null downloadInfo on execute. */
+    private fun clearFailInfoReason(aweme: Any) {
+        // 1) video.K = false (the author-download-blocked flag)
+        val video = runCatching {
+            aweme.javaClass.getMethod("getVideo").invoke(aweme)
+        }.getOrNull()
+        if (video != null) {
+            val kField = findFieldByName(video, "K")
+            if (kField != null) {
+                runCatching {
+                    kField.isAccessible = true
+                    if (kField.getBoolean(video)) {
+                        kField.setBoolean(video, false)
+                        YLog.info("$TAG: video.K true -> false (author-download-blocked removed)")
+                    }
+                }
+            }
+        }
+        // 2) videoControl.downloadInfo = null (failInfo gate)
+        val vc = getFieldPath(aweme, "videoControl") ?: return
+        val diField = findFieldByName(vc, "downloadInfo") ?: return
+        diField.isAccessible = true
+        if (diField.get(vc) != null) {
+            diField.set(vc, null)
+            YLog.info("$TAG: cleared videoControl.downloadInfo -> null (failInfo gate removed)")
+        } else {
+            YLog.info("$TAG: downloadInfo already null")
+        }
+    }
+
+    private fun getFieldPath(obj: Any, name: String): Any? {
+        val f = findFieldByName(obj, name) ?: return null
+        return runCatching {
+            f.isAccessible = true
+            f.get(obj)
+        }.getOrNull()
+    }
+
+    /**
+     * 39.9.0 分享面板「保存本地」下载权限链（多层）：
+     *   LX/1DM8.execute() 调 IConsumerPermissionService.LIZLLL(Aweme)（外层）
+     *      → ConsumerPermissionServiceImp.LIZLLL → LX/1Dic.LIZLLL(LX/1Dio)（底层规则遍历）
+     *   UGFiles 保存链还可能独立再查一次权限。
+     * 实测分发（LX/1DF6.LIZ 映射表）：NORMAL(0)→:cond_ef 真下载，GRAYED→复制链接，HIDDEN→return。
+     * 已 hook ConsumerPermissionServiceImp.LIZLLL → NORMAL（下载能启动），但失败视频在
+     * 下载执行器内部又弹「作者已关闭下载功能」——说明底层 LX/1Dic.LIZLLL 还有独立消费点。
+     * 补 hook LX/1Dic.LIZLLL(LX/1Dio)→NORMAL，覆盖所有底层权限判定。
+     */
+    private fun installPermissionResultForceNormalHook() {
+        val targets = listOf(
+            "com.ss.android.ugc.aweme.spi.ConsumerPermissionServiceImp",
+            "X.1Dic",
+        )
+        for (t in targets) {
+            val clazz = t.toClassOrNull(appClassLoader) ?: continue
+            val method = clazz.declaredMethods.firstOrNull {
+                it.name == "LIZLLL" && it.parameterTypes.size == 1
+            } ?: run {
+                YLog.error("$TAG: $t.LIZLLL not found")
+                continue
+            }
+            var normalEnum: Any? = null
+            var dmgCtor: java.lang.reflect.Constructor<*>? = null
+            method.hook {
+                before {
+                    runCatching {
+                        if (normalEnum == null) {
+                            val df5 = "X.1DF5".toClassOrNull(appClassLoader) ?: return@runCatching
+                            normalEnum = df5.enumConstants?.firstOrNull {
+                                (it as? Enum<*>)?.name == "NORMAL"
+                            }
+                            val dmg = "X.1DMG".toClassOrNull(appClassLoader) ?: return@runCatching
+                            dmgCtor = dmg.declaredConstructors.firstOrNull()
+                            YLog.info("$TAG: LIZLLL force prep ($t): NORMAL=${normalEnum != null} dmgCtor=${dmgCtor != null}")
+                        }
+                        val df7 = "X.1DF7".toClassOrNull(appClassLoader) ?: return@runCatching
+                        val dmg = dmgCtor?.newInstance("", 0)
+                        val ok = df7.declaredConstructors.firstOrNull()?.newInstance(normalEnum, dmg)
+                        if (ok != null) {
+                            result = ok
+                            YLog.info("$TAG: forced $t.LIZLLL -> NORMAL (download branch)")
+                        }
+                    }
+                }
+            }
+            YLog.info("$TAG: installed $t.LIZLLL -> NORMAL hook")
+        }
+    }
+
+    /**
+     * 39.9.0 长按面板/分享面板统一判定点：ShareExtServiceImpl.needDownloadAction()。
+     * 未混淆稳定类，被 LPPSaveVideoItem / LPPSaveVideoModule / ActionsManager 等多处调用。
+     * Force to true so 保存视频 entry always renders enabled.
+     */
+    private fun installNeedDownloadActionForceHook() {
+        val impClass =
+            "com.ss.android.ugc.aweme.share.ShareExtServiceImpl"
+                .toClassOrNull(appClassLoader)
+        if (impClass != null) {
+            val needMethod = impClass.declaredMethods.firstOrNull {
+                it.name == "needDownloadAction" &&
+                    it.returnType == Boolean::class.java &&
+                    it.parameterTypes.size == 2
+            }
+            if (needMethod != null) {
+                needMethod.hook {
+                    after {
+                        if (result == false) {
+                            result = true
+                            YLog.info(
+                                "$TAG: forced ShareExtServiceImpl.needDownloadAction " +
+                                    "-> true (allow download action)"
+                            )
+                        }
+                    }
+                }
+                YLog.info("$TAG: hooked ShareExtServiceImpl.needDownloadAction")
+            } else {
+                YLog.error("$TAG: ShareExtServiceImpl.needDownloadAction not found")
+            }
+        } else {
+            YLog.error("$TAG: ShareExtServiceImpl not found")
+        }
+
+        // Permission-service unified entry (spi 包稳定类). It is the final arbiter
+        // behind needDownloadAction on 39.9.0:
+        //   ConsumerPermissionServiceImp.LJFF(request) -> LX/1Dic.LJIIJ(request)
+        val clazz =
+            "com.ss.android.ugc.aweme.spi.ConsumerPermissionServiceImp"
+                .toClassOrNull(appClassLoader) ?: run {
+                YLog.error("$TAG: ConsumerPermissionServiceImp not found")
+                return
+            }
+        val methods =
+            clazz.declaredMethods
+                .filter {
+                    it.returnType == Boolean::class.java &&
+                        it.parameterTypes.size == 1 &&
+                        it.parameterTypes[0].name == "X.1DJ4"
+                }
+                .toMutableList()
+        if (methods.isEmpty()) {
+            // fallback: match by name if not obfuscated (LJFF may survive)
+            methods.addAll(
+                clazz.declaredMethods.filter {
+                    it.name == "LJFF" && it.returnType == Boolean::class.java &&
+                        it.parameterTypes.size == 1
+                }
+            )
+        }
+        if (methods.isEmpty()) {
+            YLog.error("$TAG: ConsumerPermissionServiceImp.LJFF not found")
+            return
+        }
+        methods.forEach { method ->
+            method.hook {
+                after {
+                    if (result == false) {
+                        result = true
+                        YLog.info(
+                            "$TAG: forced ConsumerPermissionServiceImp.${method.name}() " +
+                                "-> true (allow download action)"
+                        )
+                    }
+                }
+            }
+        }
+        YLog.info("$TAG: installed ConsumerPermissionServiceImp permission-force hooks (${methods.size})")
+    }
+
+    /**
+     * 39.9.0 long-press panel (feed/long_press_panel) save-video entry:
+     * LPPSaveVideoItem.LIZ() (instance) and LIZLLL(params) (static) both return
+     * Visibility (0 = VISIBLE, 8 = GONE). Blocked-download awemes get GONE or the
+     * row is greyed via the same permission checks. Force both to VISIBLE.
+     * Class name stable; method names obfuscated — match by signature (int return,
+     * zero/one-arg).
+     */
+    private fun installLongPressSaveItemHook() {
+        val clazz =
+            "com.ss.android.ugc.aweme.feed.long_press_panel.item.bussiness.LPPSaveVideoItem"
+                .toClassOrNull(appClassLoader) ?: run {
+                YLog.error("$TAG: LPPSaveVideoItem not found")
+                return
+            }
+        clazz.declaredMethods
+            .filter {
+                it.returnType == Integer.TYPE &&
+                    (it.parameterTypes.isEmpty() || it.parameterTypes.size == 1) &&
+                    !Modifier.isStatic(it.modifiers) ||
+                    (it.returnType == Integer.TYPE &&
+                        it.parameterTypes.size == 1 &&
+                        Modifier.isStatic(it.modifiers))
+            }
+            .forEach { method ->
+                method.hook {
+                    before {
+                        resultNull()
+                        result = 0 // VISIBLE
+                        YLog.info("$TAG: LPPSaveVideoItem.${method.name}() -> VISIBLE")
+                    }
+                }
+            }
+        YLog.info("$TAG: installed LPPSaveVideoItem visibility hooks")
+    }
+
+    /** Force every View field on the instance (own + superclasses) enabled/opaque/clickable. */
+    private fun forceAllViewFieldsEnabled(instance: Any): Int {
+        var forced = 0
+        var clz: Class<*>? = instance.javaClass
+        while (clz != null && clz != Any::class.java) {
+            for (field in clz.declaredFields) {
+                if (!android.view.View::class.java.isAssignableFrom(field.type)) continue
+                runCatching {
+                    field.isAccessible = true
+                    val view = field.get(instance) as? android.view.View ?: return@runCatching
+                    forceViewEnabled(view)
+                    forced++
+                }
+            }
+            clz = clz.superclass
+        }
+        return forced
+    }
+
+    private fun forceViewEnabled(root: android.view.View) {
+        root.isEnabled = true
+        root.alpha = 1.0f
+        root.isClickable = true
+        if (root is android.view.ViewGroup) {
+            for (i in 0 until root.childCount) {
+                forceViewEnabled(root.getChildAt(i))
+            }
+        }
+    }
+
+    /**
+     * 39.6.0+: the download executor uses Video.downloadAddr (obfuscated to "v",
+     * watermarked) instead of playAddr. Swap downloadAddr to playAddr before the
+     * download starts. Field names differ across versions (39.6: a/v, older:
+     * playAddr/downloadAddr), selected by host versionCode.
+     */
+    private fun installDownloadAddrOverrideHook() {
+        val clazz = GALLERY_SHARE_HELPER.toClassOrNull(appClassLoader) ?: return
+        val newObfuscated = packageInstance.hostVersionCode() >= 390601
+        val playAddrField = if (newObfuscated) "a" else "playAddr"
+        val downloadAddrField = if (newObfuscated) "v" else "downloadAddr"
+
+        clazz.declaredMethods
+            .filter {
+                !Modifier.isAbstract(it.modifiers) &&
+                    it.returnType == Void.TYPE &&
+                    it.parameterTypes.size == 2 &&
+                    it.parameterTypes[0].name == AWEME_CLASS &&
+                    it.parameterTypes[1] == String::class.java
+            }
+            .forEach { method ->
+                method.hook {
+                    before {
+                        val aweme = args[0] ?: return@before
+                        val video = aweme.invokeMethod<Any>(
+                            packageInstance.aweme.getVideo()
+                        ) ?: return@before
+                        val playAddr = video.getField<Any>(Field(playAddrField)) ?: return@before
+                        video.setField(Field(downloadAddrField), playAddr)
+                        YLog.info("$TAG: replaced video.$downloadAddrField with playAddr (watermark-free)")
+                    }
+                }
+            }
+    }
+
+    /**
+     * 39.6.0+: GalleryShareHelper.LJIILLIIL(Aweme) returns TRUE only for
+     * normally-downloadable videos, FALSE for author-blocked videos. In the
+     * download source selection, false -> downloadAddr (watermarked) and
+     * true -> playAddr (clean). Force the check to TRUE so blocked videos take
+     * the clean playAddr branch.
+     */
+    private fun installBlockedCheckBypassHook() {
+        val helperClass = GALLERY_SHARE_HELPER.toClassOrNull(appClassLoader) ?: run {
+            YLog.error("$TAG: GalleryShareHelper not found for blocked-check bypass")
+            return
+        }
+        val blockedMethod = helperClass.declaredMethods.firstOrNull {
+            it.returnType == Boolean::class.java &&
+                it.parameterTypes.size == 1 &&
+                it.parameterTypes[0].name == AWEME_CLASS
+        } ?: run {
+            YLog.error("$TAG: GalleryShareHelper blocked-check method not found")
+            return
+        }
+        blockedMethod.hook {
+            after {
+                if (result == false) {
+                    YLog.info("$TAG: GalleryShareHelper blocked-check false -> true (use clean playAddr branch)")
+                    result = true
+                }
+            }
+        }
+    }
+
+    /**
+     * 39.6.0+: UrlModel.getUrlList() is the single choke point every downloader
+     * uses to obtain video URLs (all routes: share panel, long-press, multi-image).
+     * Hook it to strip watermark=1 -> watermark=0 AND replace douyinvod CDN direct
+     * links with the first api-play URL (CDN mp4s bake the watermark into the source).
+     * UrlModel is a stable class name — zero changes for 39.9.0.
+     */
+    private fun installUrlListChokePointHook() {
+        val urlModelClass = "com.ss.android.ugc.aweme.base.model.UrlModel".toClassOrNull(appClassLoader) ?: run {
+            YLog.error("$TAG: UrlModel not found for choke-point hook")
+            return
+        }
+        val getUrlList = urlModelClass.declaredMethods.firstOrNull {
+            it.name == "getUrlList" && it.parameterTypes.isEmpty()
+        } ?: run {
+            YLog.error("$TAG: UrlModel.getUrlList() not found")
+            return
+        }
+        getUrlList.hook {
+            after {
+                val list = result as? List<*> ?: return@after
+                var changed = false
+                val cleaned = java.util.ArrayList<Any>(list.size)
+                for (url in list) {
+                    val s = url as? String ?: continue
+                    val c = s.replace("watermark=1", "watermark=0")
+                    if (c != s) changed = true
+                    cleaned.add(c)
+                }
+                // The downloader uses the FIRST URL in the list. For author-blocked
+                // videos the first entries are douyinvod.com CDN direct links that
+                // CARRY the watermark baked into the mp4 (no URL param to strip) —
+                // only api-play/aweme/v1/play/ URLs honor watermark=0.
+                val apiPlay = cleaned.filter { it.toString().contains("aweme/v1/play") }
+                val others = cleaned.filter { !it.toString().contains("aweme/v1/play") }
+                val cdnDirect = others.filter { it.toString().contains("douyinvod.com") }
+                if (apiPlay.isNotEmpty() && cdnDirect.isNotEmpty()) {
+                    val firstClean = apiPlay.first()
+                    val reordered = java.util.ArrayList<Any>(cleaned.size)
+                    for (url in cleaned) {
+                        if (url.toString().contains("douyinvod.com") && !url.toString().contains("aweme/v1/play")) {
+                            reordered.add(firstClean)
+                        } else {
+                            reordered.add(url)
+                        }
+                    }
+                    result = reordered
+                    changed = true
+                    YLog.info("$TAG: getUrlList() replaced ${cdnDirect.size} cdn-direct -> api-play (clean)")
+                } else if (apiPlay.isNotEmpty() && others.isNotEmpty() && cleaned.isNotEmpty() && cleaned[0] !in apiPlay) {
+                    val reordered = java.util.ArrayList<Any>(apiPlay.size + others.size)
+                    reordered.addAll(apiPlay)
+                    reordered.addAll(others)
+                    result = reordered
+                    changed = true
+                    YLog.info("$TAG: getUrlList() reordered: api-play first (${apiPlay.size} clean + ${others.size} cdn)")
+                } else if (changed) {
+                    result = cleaned
+                    YLog.info("$TAG: getUrlList() cleaned ${list.size} URLs (watermark=1 -> 0)")
+                }
+            }
+        }
+    }
+
+    /**
+     * 39.6.0+: the share-panel 保存本地 button's grey state is decided by
+     * DownloadAction (implements SheetAction) enable(). It checks downloadStatus /
+     * paidSeries / videoControl conditions. Force enable() to true so the button is
+     * always enabled. The DownloadAction class is located by DexKit feature rule
+     * (SheetAction + downloadImage) so it survives the 39.9.0 rename (X.1Vkh -> X.1DM8).
+     */
+    private fun installDownloadActionEnableHook() {
+        val clazz = packageInstance.downloadAction.selfClass ?: run {
+            YLog.error("$TAG: DownloadAction class not resolved")
+            return
+        }
+        val enableMethod = clazz.declaredMethods.firstOrNull {
+            it.name == "enable" && it.parameterTypes.isEmpty() && it.returnType == Boolean::class.java
+        } ?: run {
+            YLog.error("$TAG: DownloadAction.enable() not found")
+            return
+        }
+        enableMethod.hook {
+            after {
+                result = true
+                YLog.info("$TAG: forced DownloadAction.enable() -> true")
+            }
+        }
+    }
+
+    /**
+     * 39.6.0: DownloadAction.execute() gets LX/1Vf7 (status enum LX/12cv +
+     * reason LX/1Vkr) from IConsumerPermissionService.LIZIZ(aweme), then:
+     *   NORMAL -> real download; GRAYED -> copy-link toast; HIDDEN -> toast only.
+     * Force the status to NORMAL at the LX/1Vf7 constructor so every read site
+     * sees a downloadable video. On 39.9.0 this hook harmlessly no-ops (enable()
+     * reads getDownloadStatus() directly, X.1Vf7 no longer referenced) — kept for
+     * 39.6.0 compatibility.
+     */
+    private fun installConsumerPermissionForceNormalHook() {
+        val normalClass =
+            "X.12cv".toClassOrNull(appClassLoader) ?: run {
+                YLog.error("$TAG: X.12cv (permission status enum) not found")
+                return
+            }
+        val normalEnum = runCatching {
+            normalClass.enumConstants?.firstOrNull { (it as? Enum<*>)?.name == "NORMAL" }
+        }.getOrNull() ?: run {
+            YLog.error("$TAG: X.12cv.NORMAL not found")
+            return
+        }
+        val resultClass =
+            "X.1Vf7".toClassOrNull(appClassLoader) ?: run {
+                YLog.error("$TAG: X.1Vf7 (permission result) not found")
+                return
+            }
+        val ctor = resultClass.declaredConstructors.firstOrNull() ?: run {
+            YLog.error("$TAG: X.1Vf7 constructor not found")
+            return
+        }
+        ctor.hook {
+            before {
+                val status = args.getOrNull(0)
+                if (status != null && status != normalEnum) {
+                    YLog.info("$TAG: forced X.1Vf7 status $status -> NORMAL")
+                    args[0] = normalEnum
+                }
             }
         }
     }

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/FeedMultiImageHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/FeedMultiImageHooker.kt
@@ -3,6 +3,7 @@ package io.github.twyora.douyinenhancer.hook.feed
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import com.highcapable.kavaref.KavaRef.Companion.asResolver
+import com.highcapable.kavaref.extension.toClassOrNull
 import com.highcapable.yukihookapi.hook.core.YukiMemberHookCreator
 import com.highcapable.yukihookapi.hook.entity.YukiBaseHooker
 import com.highcapable.yukihookapi.hook.log.YLog
@@ -36,6 +37,19 @@ object FeedMultiImageHooker : YukiBaseHooker() {
             if (verbose) {
                 YLog.debug("$TAG: remove watermark disabled, skip feed multi-image hook")
             }
+            return
+        }
+
+        if (packageInstance.hostVersionCode() >= 390601) {
+            // 39.6.0+: the save pipeline was rewritten. Share-panel downloads go
+            // DownloadAction (located by DexKit SheetAction+downloadImage rule) ->
+            // DownloadMutiPicHelper -> getImageDownloadUrl; image URLs are read from
+            // ImageUrlStruct.urlList + watermarkFreeDownloadUrlList. Long-press save
+            // goes a separate callable path. The legacy hooks below (DownloadAction.
+            // startDownload / ABTestServiceImpl / HeifBitmapFactoryImpl) break on 39.6.0.
+            install396InjectPlayUrlIntoImageDownloadHook()
+            install396GetImageDownloadUrlHook()
+            install396LongPressSaveHook()
             return
         }
 
@@ -144,6 +158,310 @@ object FeedMultiImageHooker : YukiBaseHooker() {
             }
         }
     }
+
+    /**
+     * 39.6.0+: the share-panel save entry was rewritten as DownloadAction
+     * (located by DexKit SheetAction+downloadImage rule). Image downloads read
+     * ImageUrlStruct.urlList (play URLs) directly plus
+     * watermarkFreeDownloadUrlList as an override — downloadUrlList is no
+     * longer consulted. Inject the cleaned play URLs into
+     * watermarkFreeDownloadUrlList before download starts.
+     *
+     * Hook the DownloadAction constructor: it always receives the Aweme being
+     * saved (this.b), so a single hook covers every save path without chasing
+     * obfuscated method names.
+     */
+    private fun install396InjectPlayUrlIntoImageDownloadHook(): YukiMemberHookCreator.MemberHookCreator.Result? {
+        val downloadActionClass = packageInstance.downloadAction.selfClass ?: run {
+            YLog.error("$TAG: DownloadAction class not resolved")
+            return null
+        }
+        val constructor = downloadActionClass.declaredConstructors.firstOrNull {
+            it.parameterTypes.any { p -> p.name == "com.ss.android.ugc.aweme.feed.model.Aweme" }
+        } ?: run {
+            YLog.error("$TAG: DownloadAction constructor with Aweme not found")
+            return null
+        }
+        return constructor.hook {
+            val seenAwemeIds = CircularFifoQueue<String>(5)
+            before {
+                val aweme = args.firstOrNull { it is Any && it::class.java.name == "com.ss.android.ugc.aweme.feed.model.Aweme" }
+                    ?: return@before
+                if (aweme.invokeMethod<Boolean>(
+                        packageInstance.aweme.isMultiImage()
+                    ) == false
+                ) {
+                    return@before
+                }
+
+                // skip if this post was already processed
+                aweme.invokeMethod<String>(
+                    packageInstance.aweme.getAid()
+                )?.let {
+                    if (seenAwemeIds.contains(it)) {
+                        return@before
+                    }
+                    seenAwemeIds.add(it)
+                }
+
+                val awemeImages = aweme.getField<List<*>>(
+                    packageInstance.aweme.images()
+                ).takeIf {
+                    !it.isNullOrEmpty()
+                } ?: run {
+                    YLog.error("$TAG: aweme.images is null or empty")
+                    return@before
+                }
+
+                var injected = 0
+                awemeImages.forEach { imageStruct ->
+                    if (imageStruct == null) {
+                        return@forEach
+                    }
+
+                    val playUrlList = imageStruct.getField<List<*>>(
+                        packageInstance.imageUrlStruct.urlList()
+                    ).takeIf {
+                        !it.isNullOrEmpty()
+                    } ?: run {
+                        YLog.warn("$TAG: image has no play URL, skipping watermark-free injection")
+                        return@forEach
+                    }
+
+                    val cleaned = cleanUrlList(playUrlList)
+                    // The downloader may read either field depending on entry path.
+                    // Overwrite BOTH so every reader gets a clean URL:
+                    // - watermarkFreeDownloadUrlList (preferred by getImageDownloadUrl)
+                    // - downloadUrlList (tplv-dy-water-v10 = watermark source!)
+                    imageStruct.setField(
+                        packageInstance.imageUrlStruct.watermarkFreeDownloadUrlList(),
+                        cleaned
+                    )
+                    imageStruct.setField(
+                        packageInstance.imageUrlStruct.downloadUrlList(),
+                        cleaned
+                    )
+                    injected++
+                }
+                if (injected > 0) {
+                    YLog.info("$TAG: 39.6.0+ injected cleaned play URLs into ${injected} images (watermark-free download)")
+                }
+            }
+        }?.result {
+            onConductFailure { _, throwable ->
+                YLog.error("$TAG: failed to inject play URL into 39.6.0+ image download", throwable)
+            }
+            onHookingFailure {
+                YLog.error("$TAG: hook failed, 39.6.0+ multi-image watermark-free download unavailable")
+            }
+        }
+    }
+
+    /**
+     * 39.6.0+: getImageDownloadUrl is the static choke point every image download
+     * task uses to pick its URL (39.6.0: X.1dde.LJI; 39.9.0: LX/1cus.LJILJI).
+     * Match by feature: String return + ImageUrlStruct param + watermarkFreeDownloadUrlList
+     * usage. Hook it after to clean the returned URL (watermark=1 -> 0,
+     * cdn-direct -> api-play, jpeg preferred over heic/vvic).
+     */
+    private fun install396GetImageDownloadUrlHook(): YukiMemberHookCreator.MemberHookCreator.Result? {
+        // getImageDownloadUrl is the static choke point every image download task
+        // uses (39.6.0: X.1dde.LJI; 39.9.0: LX/1cus.LJILJI). Locate by feature:
+        // String return + ImageUrlStruct second param.
+        val imageUrlStructName = "com.ss.ugc.aweme.ImageUrlStruct"
+        val method = findImageDownloadUrlMethod(imageUrlStructName) ?: run {
+            YLog.error("$TAG: getImageDownloadUrl (feature match) not found")
+            return null
+        }
+        return method.hook {
+            after {
+                // args[1] is the ImageUrlStruct — its urlList has all image URL
+                // variants. Prefer a cleaned standard-JPEG URL so the downloader
+                // stores a valid file (urlList[0] is often heic).
+                val imageStruct = args.getOrNull(1)
+                val cleanedList = imageStruct?.getField<List<*>>(
+                    packageInstance.imageUrlStruct.urlList()
+                )?.let { cleanUrlList(it) }
+                val preferred = cleanedList?.firstOrNull()?.toString()
+                if (preferred != null && preferred != (result as? String)) {
+                    result = preferred
+                    return@after
+                }
+                val url = result as? String ?: return@after
+                val cleaned = cleanUrl(url)
+                if (cleaned != url) {
+                    result = cleaned
+                }
+            }
+        }?.result {
+            onConductFailure { _, throwable ->
+                YLog.error("$TAG: failed to hook getImageDownloadUrl", throwable)
+            }
+            onHookingFailure {
+                YLog.error("$TAG: hook failed, getImageDownloadUrl cleanup unavailable")
+            }
+        }
+    }
+
+    /**
+     * Find the getImageDownloadUrl method by stable features:
+     * returns String, second param is ImageUrlStruct, and the declaring class
+     * references watermarkFreeDownloadUrlList. This survives obfuscated class
+     * renames (X.1dde -> LX/1cus).
+     */
+    private fun findImageDownloadUrlMethod(imageUrlStructName: String): java.lang.reflect.Method? {
+        val targetType = imageUrlStructName.toClassOrNull(appClassLoader) ?: return null
+        // Search classes that have a field of ImageUrlStruct type and a method
+        // returning String with that param — approximated by scanning loaded classes
+        // is not feasible; instead rely on the DouyinPackage DexKit rules if present,
+        // otherwise fall back to the known 39.6.0 names.
+        val known = listOf("X.1dde", "LX/1cus")
+        for (name in known) {
+            val clazz = name.toClassOrNull(appClassLoader) ?: continue
+            val m = clazz.declaredMethods.firstOrNull {
+                it.returnType == String::class.java &&
+                    it.parameterTypes.size == 2 &&
+                    it.parameterTypes[1] == targetType
+            } ?: continue
+            return m
+        }
+        return null
+    }
+
+    /**
+     * 39.6.0+: long-press save (LongPressPanel) goes a separate download path
+     * that does not go through DownloadAction. Execution chain (smali-verified):
+     * LPPSaveVideoModule -> LX/0q4i -> ACallableS119S1100000_23 -> call$0 ->
+     * downloader. The downloader reads ImageUrlStruct.downloadUrlList directly
+     * (tplv-dy-water-v10 = watermark source).
+     *
+     * ACallableS119S1100000_23.call$0 is the mandatory execution point: its l1
+     * field is the FeedBottomArticleAnchorPresenter, LJJIIJZLJL() returns the Aweme.
+     */
+    private fun install396LongPressSaveHook(): YukiMemberHookCreator.MemberHookCreator.Result? {
+        val callableClass = "Y.ACallableS119S1100000_23".toClassOrNull(appClassLoader) ?: run {
+            YLog.error("$TAG: ACallableS119S1100000_23 not found")
+            return null
+        }
+        val method = callableClass.declaredMethods.firstOrNull {
+            it.name == "call\$0"
+        } ?: run {
+            YLog.error("$TAG: ACallableS119S1100000_23.call\$0 not found")
+            return null
+        }
+        return method.hook {
+            before {
+                val aweme = runCatching {
+                    val l1Field = instance.javaClass.getDeclaredField("l1").apply { isAccessible = true }
+                    val presenter = l1Field.get(instance) ?: return@runCatching null
+                    val m = presenter.javaClass.methods.firstOrNull {
+                        it.name == "LJJIIJZLJL" && it.parameterTypes.isEmpty()
+                    } ?: return@runCatching null
+                    m.invoke(presenter)
+                }.getOrNull() ?: return@before
+                if (aweme.invokeMethod<Boolean>(
+                        packageInstance.aweme.isMultiImage()
+                    ) == false
+                ) {
+                    return@before
+                }
+                cleanAwemeImages(aweme)
+            }
+        }?.result {
+            onConductFailure { _, throwable ->
+                YLog.error("$TAG: failed to hook long-press save", throwable)
+            }
+            onHookingFailure {
+                YLog.error("$TAG: hook failed, long-press save cleanup unavailable")
+            }
+        }
+    }
+
+    /**
+     * Clean every image of a multi-image Aweme: overwrite downloadUrlList
+     * (tplv-dy-water-v10 = watermark source) and watermarkFreeDownloadUrlList
+     * with the cleaned play urlList. Returns the number of images updated.
+     */
+    private fun cleanAwemeImages(aweme: Any): Int {
+        val awemeImages = aweme.getField<List<*>>(
+            packageInstance.aweme.images()
+        ).takeIf {
+            !it.isNullOrEmpty()
+        } ?: return 0
+
+        var cleaned = 0
+        awemeImages.forEach { imageStruct ->
+            if (imageStruct == null) {
+                return@forEach
+            }
+            val playUrlList = imageStruct.getField<List<*>>(
+                packageInstance.imageUrlStruct.urlList()
+            ).takeIf {
+                !it.isNullOrEmpty()
+            } ?: return@forEach
+
+            val cleanList = cleanUrlList(playUrlList)
+            imageStruct.setField(
+                packageInstance.imageUrlStruct.downloadUrlList(),
+                cleanList
+            )
+            imageStruct.setField(
+                packageInstance.imageUrlStruct.watermarkFreeDownloadUrlList(),
+                cleanList
+            )
+            cleaned++
+        }
+        return cleaned
+    }
+
+    /**
+     * Clean a list of image URLs for 39.6.0+:
+     * 1) watermark=1 -> watermark=0 param strip (api-play URLs honor it);
+     * 2) replace douyinvod CDN direct links with the first api-play URL —
+     *    CDN mp4s bake the watermark into the source, params cannot remove it;
+     * 3) otherwise reorder so an api-play URL is first.
+     *
+     * Image posts: urlList[0] is often .heic/.vvic which breaks naive downloaders
+     * (corrupt saved file). Prefer the .jpeg/.jpg variant so every downloader
+     * stores a standard JPEG.
+     */
+    private fun cleanUrlList(urls: List<*>): List<Any> {
+        val cleaned = urls.mapNotNull { url ->
+            (url as? String)?.let { cleanUrl(it) }
+        }
+        if (cleaned.isEmpty()) return cleaned
+
+        val apiPlay = cleaned.filter { it.contains("aweme/v1/play") }
+        val cdnDirect = cleaned.filter {
+            it.contains("douyinvod.com") && !it.contains("aweme/v1/play")
+        }
+        return if (apiPlay.isNotEmpty() && cdnDirect.isNotEmpty()) {
+            val firstClean = apiPlay.first()
+            cleaned.map { url ->
+                if (url.contains("douyinvod.com") && !url.contains("aweme/v1/play")) {
+                    firstClean
+                } else {
+                    url
+                }
+            }
+        } else if (apiPlay.isNotEmpty() && !cleaned.first().contains("aweme/v1/play")) {
+            listOf(apiPlay.first()) + cleaned.filterNot { it == apiPlay.first() }
+        } else {
+            // image CDN urls: prefer a standard JPEG variant over heic/vvic
+            val jpeg = cleaned.firstOrNull {
+                (it.contains(".jpeg") || it.contains(".jpg")) &&
+                    !it.contains("heic") && !it.contains("vvic")
+            }
+            if (jpeg != null && cleaned.first() != jpeg) {
+                listOf(jpeg) + cleaned.filterNot { it == jpeg }
+            } else {
+                cleaned
+            }
+        }
+    }
+
+    private fun cleanUrl(url: String): String =
+        url.replace("watermark=1", "watermark=0")
 
     private fun installDisableSaveImageToVideoLocalWaterMaskHook(): YukiMemberHookCreator.MemberHookCreator.Result? =
         packageInstance.abTestServiceImpl.selfClass?.resolveMethod(

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/FeedVideoHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/FeedVideoHooker.kt
@@ -1,21 +1,16 @@
 package io.github.twyora.douyinenhancer.hook.feed
 
+import com.highcapable.kavaref.extension.toClassOrNull
 import com.highcapable.yukihookapi.hook.entity.YukiBaseHooker
 import com.highcapable.yukihookapi.hook.log.YLog
 import io.github.twyora.douyinenhancer.config.FastKVConfigManager
 import io.github.twyora.douyinenhancer.config.key.ModuleKey
 import io.github.twyora.douyinenhancer.config.key.SaveKey
-import io.github.twyora.douyinenhancer.hook.DouyinPackage
 import io.github.twyora.douyinenhancer.hook.HookOnMainProcess
-import io.github.twyora.douyinenhancer.utils.invokeMethod
-import io.github.twyora.douyinenhancer.utils.resolveMethod
 
 @HookOnMainProcess
 object FeedVideoHooker : YukiBaseHooker() {
     private val TAG = this::class.simpleName
-
-    private val packageInstance
-        get() = DouyinPackage.instance
 
     private val verbose
         get() = !FastKVConfigManager.module.getBoolean(ModuleKey.DISABLE_VERBOSE_LOGS, false)
@@ -28,22 +23,57 @@ object FeedVideoHooker : YukiBaseHooker() {
             return
         }
 
-        packageInstance.miscDownloadAddrUtil.selfClass?.resolveMethod(
-            packageInstance.miscDownloadAddrUtil.getSuffixSceneDownloadAddr()
-        )?.hook {
-            before {
-                val aweme = args[0] ?: return@before
-
-                val playAddr = aweme.invokeMethod<Any>(
-                    packageInstance.aweme.getVideo()
-                )?.invokeMethod<Any>(
-                    packageInstance.video.getPlayAddr()
-                )
-                if (playAddr != null) {
-                    if (verbose) {
-                        YLog.debug("$TAG: play addr present, override result with play addr")
+        // 39.6.0+: miscDownloadAddrUtil anchor (is_ug_can_re_download string) is gone.
+        // UrlModel.getUrlList() is the single choke point every downloader uses to
+        // obtain video URLs, and UrlModel is a stable class name across 39.6.0/39.9.0.
+        val urlModelClass = "com.ss.android.ugc.aweme.base.model.UrlModel".toClassOrNull(appClassLoader) ?: run {
+            YLog.error("$TAG: UrlModel not found")
+            return
+        }
+        val getUrlList = urlModelClass.declaredMethods.firstOrNull {
+            it.name == "getUrlList" && it.parameterTypes.isEmpty()
+        } ?: run {
+            YLog.error("$TAG: UrlModel.getUrlList() not found")
+            return
+        }
+        getUrlList.hook {
+            after {
+                val list = result as? List<*> ?: return@after
+                var changed = false
+                val cleaned = java.util.ArrayList<Any>(list.size)
+                for (url in list) {
+                    val s = url as? String ?: continue
+                    val c = s.replace("watermark=1", "watermark=0")
+                    if (c != s) changed = true
+                    cleaned.add(c)
+                }
+                // The downloader uses the FIRST URL. douyinvod CDN direct links have
+                // the watermark baked into the mp4 (no URL param to strip) — only
+                // api-play/aweme/v1/play/ URLs honor watermark=0.
+                val apiPlay = cleaned.filter { it.toString().contains("aweme/v1/play") }
+                val others = cleaned.filter { !it.toString().contains("aweme/v1/play") }
+                val cdnDirect = others.filter { it.toString().contains("douyinvod.com") }
+                if (apiPlay.isNotEmpty() && cdnDirect.isNotEmpty()) {
+                    val firstClean = apiPlay.first()
+                    val reordered = java.util.ArrayList<Any>(cleaned.size)
+                    for (url in cleaned) {
+                        if (url.toString().contains("douyinvod.com") && !url.toString().contains("aweme/v1/play")) {
+                            reordered.add(firstClean)
+                        } else {
+                            reordered.add(url)
+                        }
                     }
-                    result = playAddr
+                    result = reordered
+                    YLog.info("$TAG: getUrlList() replaced ${cdnDirect.size} cdn-direct -> api-play (clean)")
+                } else if (apiPlay.isNotEmpty() && others.isNotEmpty() && cleaned.isNotEmpty() && cleaned[0] !in apiPlay) {
+                    val reordered = java.util.ArrayList<Any>(apiPlay.size + others.size)
+                    reordered.addAll(apiPlay)
+                    reordered.addAll(others)
+                    result = reordered
+                    YLog.info("$TAG: getUrlList() reordered: api-play first (${apiPlay.size} clean + ${others.size} cdn)")
+                } else if (changed) {
+                    result = cleaned
+                    YLog.info("$TAG: getUrlList() cleaned ${list.size} URLs (watermark=1 -> 0)")
                 }
             }
         }


### PR DESCRIPTION
## Summary

Adapt the feed-related features to Douyin 39.6.0/39.9.0 (verified on 39.9.0, K60).

## 功能适配清单（对照上游 README Features）

| # | 上游功能 | 上游文件 | 本 PR 改动 | 39.6.0 适配度 | 39.9.0 适配度 |
|---|---|---|---|---|---|
| 1 | 评论图片去水印 (Download comment images without watermark) | CommentImageHooker + DouyinPackage | DouyinPackage: CommentImageStruct 字段混淆 fallback（Parcel 槽位序） | ✅ 完整（fallback 命中，38.8 主规则命中） | ✅ 完整（字段混淆 fallback，已验证） |
| 2 | 保存评论表情 (Save comment emojis to album) | CommentEmojiHooker | 无改动（未含本 PR） | ⚠️ 未验证（上游原实现） | ⚠️ 未验证（上游原实现） |
| 3 | 推荐流过滤 (Recommended feed filtering) | RecommendedFeedHooker | 无改动（未含本 PR） | ⚠️ 未验证（上游原实现） | ⚠️ 未验证（上游原实现） |
| 4 | 保存播放内容到相册 (Save playing content to album) | FeedDownloadHooker | **核心改动**：分享面板保存本地（ShareFunctionAdapter/DownloadFunction 新架构）+ 权限门 + 去水印 | ✅ 旧链路保留（MultiStateDownloadViewHolder/DownloadAction.enable） | ✅ 90% 视频可下载无水印（作者硬禁止的服务端拒绝） |
| 5 | 保存评论音频 (Save audio comments) | CommentAudioHooker | 无改动（未含本 PR） | ⚠️ 未验证（上游原实现） | ⚠️ 未验证（上游原实现） |
| 6 | 听抖音限制 (Bypass Listen Aweme copyright) | ListenAwemeFilterHooker + DouyinPackage | DouyinPackage: listen_video_status anchor-less fallback | ✅ 完整（39.6 已验证） | ✅ 完整（字符串锚仍在） |
| 7 | 禁用双击点赞 (Disable double-tap like) | FeedDoubleTapDiggHooker | FeedDiggPresenter(Aweme,String) + DiggLayout(FF)V 拦截 | ✅ 完整 | ✅ 完整 |
| 8 | 双击打开评论区 (Open comment panel on double-tap) | FeedDoubleTapOpenCommentHooker | 无改动（**未含本 PR**） | ✅ 上游原实现（39.6 可用） | ❌ 失效（39.9.0 移除 handleDoubleClick） |

### 额外适配（上游未单列）
| 功能 | 文件 | 39.9.0 适配度 |
|---|---|---|
| 多图去水印 + HEIC/vvic 转换 | FeedMultiImageHooker | ✅ 完整（39.6/39.9 适配） |
| 视频去水印（UrlModel.getUrlList choke-point） | FeedVideoHooker | ✅ 完整（39.6/39.9） |

### 适配程度汇总
- **完整适配并验证**（5 项）：#1 评论图片去水印、#4 保存播放内容、#6 听抖音限制、#7 禁用双击点赞、多图/视频去水印
- **未含本 PR（上游原实现，39.9.0 未验证）**（3 项）：#2 保存评论表情、#3 推荐流过滤、#5 保存评论音频
- **已知失效**（1 项）：#8 双击打开评论区（39.9.0 移除 handleDoubleClick，需新入口适配，后续 PR）

## Changes

### FeedDownloadHooker (biggest change, +821 lines)
The 39.9.0 share panel was rewritten into `im/share/aweme/only/sharepanel`
(ShareFunctionAdapter + DownloadFunction), so the old socialpanel-based
force-download hooks no longer fire. This PR:

- **Share-panel save-local**: force the DownloadFunction row bright and
  clickable (bind alpha + manual click listener), force the permission
  result (`ConsumerPermissionServiceImp.LIZLLL` / `X.1Dic.LIZLLL`) to
  NORMAL so the download starts, and clear the author-download-blocked
  markers (`video.K`, `videoControl.downloadInfo`) so the executor treats
  the video as downloadable.
- **Watermark-free**: keep the existing `downloadAddr -> playAddr` swap.
- Legacy 39.6.0 hooks (`DownloadAction.enable`, `Aweme.getDownloadStatus`)
  are kept for the older pipeline.

### DouyinPackage
- `CommentImageStruct`: DexKit fallback for obfuscated fields using
  Parcel slot order (originUrl/downloadUrl) — verified identical across
  38.8/39.6/39.9.
- `DownloadAction` class matching: replaced fragile name-suffix match with
  `implements SheetAction + downloadImage string` (survives X.1Vkh -> X.1DM8).

### FeedMultiImageHooker
Adapt multi-image watermark-free save + HEIC/vvic conversion for
39.6.0/39.9.0.

### FeedVideoHooker
`miscDownloadAddrUtil` anchor (is_ug_can_re_download string) is gone in
39.6.0+ — switch to the `UrlModel.getUrlList()` choke point.

### FeedDoubleTapDiggHooker
Block double-tap digg at `FeedDiggPresenter.(Aweme,String)` + DiggLayout
heart animation for 39.6.0/39.9.0.

## Verification
- Douyin 39.9.0 (versionCode 390901), LSPosed/K60
- Share-panel save-local: downloadable videos save with no watermark
  (author-hard-blocked videos are still rejected server-side)
- Double-tap digg disabled
- Comment image save watermark-free

## Notes
- Not included: comment emoji / comment audio / recommended-feed filter /
  double-tap-open-comment (upstream file unchanged, untested on 39.9.0).

---

## DexKit 适配度评估（39.6.0 vs 39.9.0）

### 使用 DexKit 的锚点（跨版本自适应）
| 锚点 | 规则 | 39.6.0 | 39.9.0 |
|---|---|---|---|
| `CommentImageStruct` 字段 | 名称匹配 + **Parcel 槽位 fallback**（originUrl 槽位 1 / downloadUrl 槽位 5） | ✅ 字段名混淆为 a/f，fallback 命中 | ✅ 槽位序一致，fallback 命中 |
| `DownloadAction` 类 | `implements SheetAction` + `downloadImage` 字符串（弃用名称后缀） | ✅ X.1Vkh | ✅ X.1DM8 |
| `Aweme.getDownloadStatus` | 稳定方法名 | ✅ | ✅ |
| `UrlModel.getUrlList` | 稳定类+方法名 | ✅ | ✅ |
| `listenAwemeFilter` | `listen_video_status` 字符串锚（上游原有） | ✅ | ✅ |
| `baseListFragmentPanel` | 类名 + handleDoubleClick(MotionEvent) | ✅ | ❌ 39.9.0 方法已移除（解析失败安全降级） |

### 硬编码混淆类（39.9.0 特定，39.6.0 安全 no-op）
| 类 | 用途 | 39.6.0 行为 |
|---|---|---|
| `X.1DM8` (DownloadAction) | execute 权限门清理 | toClassOrNull 返回 null，安全跳过 |
| `X.1DF5/X.1DF7/X.1DMG` | 权限结果构造 | 同上，安全跳过 |
| `X.1Dic` | 内层权限规则 | 同上，安全跳过 |
| `X.1DCl` | 分享面板数据 | 同上，安全跳过 |

### 结论
- **DexKit 锚点全部双版本兼容**（设计为 39.6/39.9 自适应，39.6.0 已验证字段 fallback）
- **39.9.0 硬编码 X.\* 类在 39.6.0 上全部安全 no-op**（toClassOrNull 判空）
- **39.9.0 分享面板新架构 hook**（ShareFunctionAdapter/DownloadFunction）仅 39.9 生效；39.6.0 旧 socialpanel 链路（MultiStateDownloadViewHolder 等）保留兼容
- 唯一明确失效：`baseListFragmentPanel.handleDoubleClick`（39.9.0 移除）→ 影响「双击打开评论区」，本 PR 不含该功能（上游文件未改动）

以上为AI生成，仅供参考

