### PR TITLE
fix(settings-dialog): fix inject module app resources order

### DIFF
--- a/app/src/main/java/io/github/twyora/douyinenhancer/ui/SettingsDialog.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/ui/SettingsDialog.kt
@@ -411,7 +411,6 @@ class SettingsDialog(context: Context) : AlertDialog.Builder(ContextThemeWrapper
 
     init {
         val activity = context as Activity
-        activity.injectModuleAppResources()
 
         val prefsFragment = PrefsFragment()
         activity.fragmentManager.beginTransaction().add(prefsFragment, "Settings").commit()
@@ -480,6 +479,7 @@ class SettingsDialog(context: Context) : AlertDialog.Builder(ContextThemeWrapper
 
         fun show(context: Context) {
             runCatching {
+                (context as? Activity)?.injectModuleAppResources()
                 SettingsDialog(context).show()
             }.onFailure {
                 YLog.error("$TAG: settingDialog show failed", it)


### PR DESCRIPTION
Fix the injectModuleAppResources() order so SettingsDialog can correctly resolve R.style.MainTheme.

Previously injectModuleAppResources() ran inside SettingsDialog.init, after the AlertDialog.Builder/ContextThemeWrapper was already constructed. The wrapper therefore resolved R.style.MainTheme against the host Resources before injection completed, so in dark mode the dialog showed a light background while the module still forced the text to a light color, making it unreadable.

This did not surface in SettingsHooker because it injects module app resources early to build the module settings entry, which masked the issue.
