### PR TITLE
refactor(reflect): rework reflect utilities

### DIFF
--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/DouyinPackage.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/DouyinPackage.kt
@@ -10,7 +10,6 @@ import com.highcapable.kavaref.KavaRef.Companion.resolve
 import com.highcapable.kavaref.condition.matcher.extension.parameterizedBy
 import com.highcapable.kavaref.condition.matcher.extension.toTypeMatcher
 import com.highcapable.kavaref.condition.type.Modifiers
-import com.highcapable.kavaref.extension.toClass
 import com.highcapable.yukihookapi.hook.log.YLog
 import io.github.twyora.douyinenhancer.BuildConfig
 import io.github.twyora.douyinenhancer.config.FastKVConfigManager
@@ -18,6 +17,7 @@ import io.github.twyora.douyinenhancer.config.key.ModuleKey
 import io.github.twyora.douyinenhancer.generated.AppProperties
 import io.github.twyora.douyinenhancer.utils.Field
 import io.github.twyora.douyinenhancer.utils.Method
+import io.github.twyora.douyinenhancer.utils.toClass
 import io.github.twyora.douyinenhancer.utils.weak
 import java.io.File
 import java.io.FileInputStream

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/comment/CommentAudioHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/comment/CommentAudioHooker.kt
@@ -15,6 +15,7 @@ import io.github.twyora.douyinenhancer.utils.FileTypeDetector
 import io.github.twyora.douyinenhancer.utils.HookTransaction
 import io.github.twyora.douyinenhancer.utils.getField
 import io.github.twyora.douyinenhancer.utils.invokeMethod
+import io.github.twyora.douyinenhancer.utils.invokeMethodOnly
 import io.github.twyora.douyinenhancer.utils.invokeStaticMethod
 import io.github.twyora.douyinenhancer.utils.resolveMethod
 import io.github.twyora.douyinenhancer.utils.setField
@@ -301,7 +302,7 @@ object CommentAudioHooker : YukiBaseHooker() {
                     YLog.error("$TAG: failed to copy audio file to media store", it)
                 }.getOrDefault(false)
 
-                instance.invokeMethod<Any?>(
+                instance.invokeMethodOnly(
                     packageInstance.commentImageSaveDownloadListener.notifyResult(),
                     context,
                     copyState

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/comment/CommentEmojiHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/comment/CommentEmojiHooker.kt
@@ -23,6 +23,7 @@ import io.github.twyora.douyinenhancer.utils.HookTransaction
 import io.github.twyora.douyinenhancer.utils.getField
 import io.github.twyora.douyinenhancer.utils.getStaticField
 import io.github.twyora.douyinenhancer.utils.invokeMethod
+import io.github.twyora.douyinenhancer.utils.invokeMethodOnly
 import io.github.twyora.douyinenhancer.utils.invokeStaticMethod
 import io.github.twyora.douyinenhancer.utils.resolveMethod
 import io.github.twyora.douyinenhancer.utils.setField
@@ -307,7 +308,7 @@ object CommentEmojiHooker : YukiBaseHooker() {
                     return@before
                 }
 
-                instance.invokeMethod<Any?>(
+                instance.invokeMethodOnly(
                     packageInstance.commentImageSaveDownloadListener.notifyResult(),
                     context,
                     cpRet

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/FeedDoubleTapOpenCommentHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/FeedDoubleTapOpenCommentHooker.kt
@@ -10,6 +10,7 @@ import io.github.twyora.douyinenhancer.hook.DouyinPackage
 import io.github.twyora.douyinenhancer.hook.HookOnMainProcess
 import io.github.twyora.douyinenhancer.utils.getField
 import io.github.twyora.douyinenhancer.utils.invokeMethod
+import io.github.twyora.douyinenhancer.utils.invokeMethodOnly
 import io.github.twyora.douyinenhancer.utils.resolveMethod
 
 @HookOnMainProcess
@@ -56,7 +57,7 @@ object FeedDoubleTapOpenCommentHooker : YukiBaseHooker() {
                     YLog.debug("$TAG: dispatching open-comment-panel event for current aweme, aid: $awemeId")
                 }
 
-                instance.invokeMethod<Any>(
+                instance.invokeMethodOnly(
                     packageInstance.baseListFragmentPanel.handleVideoEvent(),
                     openCommentPanelEvent
                 )

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/FeedReplayHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/FeedReplayHooker.kt
@@ -8,7 +8,7 @@ import io.github.twyora.douyinenhancer.config.key.ModuleKey
 import io.github.twyora.douyinenhancer.hook.DouyinPackage
 import io.github.twyora.douyinenhancer.hook.HookOnMainProcess
 import io.github.twyora.douyinenhancer.utils.getField
-import io.github.twyora.douyinenhancer.utils.invokeMethod
+import io.github.twyora.douyinenhancer.utils.invokeMethodOnly
 import io.github.twyora.douyinenhancer.utils.resolveMethod
 
 @HookOnMainProcess
@@ -55,10 +55,10 @@ object FeedReplayHooker : YukiBaseHooker() {
                 } else if (verbose) {
                     YLog.debug("$TAG: pause when feed playback completes")
                 }
-                instance.invokeMethod<Any>(
+                instance.invokeMethodOnly(
                     packageInstance.baseListFragmentPanel.pauseCurrentPlayerWithListener()
                 )
-                instance.invokeMethod<Any>(
+                instance.invokeMethodOnly(
                     packageInstance.baseListFragmentPanel.showIvWhenPause()
                 )
             }

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/settings/SettingsHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/settings/SettingsHooker.kt
@@ -17,6 +17,7 @@ import io.github.twyora.douyinenhancer.hook.HookOnMainProcess
 import io.github.twyora.douyinenhancer.ui.SettingsDialog
 import io.github.twyora.douyinenhancer.utils.getField
 import io.github.twyora.douyinenhancer.utils.invokeMethod
+import io.github.twyora.douyinenhancer.utils.invokeMethodOnly
 import io.github.twyora.douyinenhancer.utils.resolveMethod
 
 @HookOnMainProcess
@@ -69,11 +70,11 @@ object SettingsHooker : YukiBaseHooker() {
                 }
                 // ensure the host app can find the module settings icon
                 activity.injectModuleAppResources()
-                moduleSettingsCommonItemView.invokeMethod<Any>(
+                moduleSettingsCommonItemView.invokeMethodOnly(
                     packageInstance.commonItemView.setLeftText(),
                     moduleAppResources.getString(R.string.app_name)
                 )
-                moduleSettingsCommonItemView.invokeMethod<Any>(
+                moduleSettingsCommonItemView.invokeMethodOnly(
                     packageInstance.commonItemView.setLeftIcon(),
                     R.drawable.ic_module_settings
                 )

--- a/app/src/main/java/io/github/twyora/douyinenhancer/ui/SettingsDialog.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/ui/SettingsDialog.kt
@@ -18,7 +18,6 @@ import android.view.View
 import android.widget.TextView
 import android.widget.Toast
 import androidx.core.content.edit
-import com.highcapable.kavaref.KavaRef.Companion.resolve
 import com.highcapable.yukihookapi.hook.factory.injectModuleAppResources
 import com.highcapable.yukihookapi.hook.log.YLog
 import io.fastkv.FastKV

--- a/app/src/main/java/io/github/twyora/douyinenhancer/ui/SettingsDialog.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/ui/SettingsDialog.kt
@@ -71,8 +71,8 @@ class SettingsDialog(context: Context) : AlertDialog.Builder(ContextThemeWrapper
 
             val prefs = FastKVConfigManager.settings
 
-            preferenceManager.setField<Any?>(Field("mSharedPreferences"), prefs)
-            preferenceManager.setField<Any?>(Field("mEditor"), null)
+            preferenceManager.setField(Field("mSharedPreferences"), prefs)
+            preferenceManager.setField(Field("mEditor"), null)
             addPreferencesFromResource(R.xml.prefs_setting)
 
             if (!prefs.getBoolean(MiscKey.ENABLE_HIDDEN_FEATURES, false)) {

--- a/app/src/main/java/io/github/twyora/douyinenhancer/utils/Reflect.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/utils/Reflect.kt
@@ -15,14 +15,23 @@ fun String.toClass(loader: ClassLoader? = null, initialize: Boolean = false): Cl
     // KavaRef's toClass doesn't support primitive types and JVM descriptors, manually handle them here
     return when (this) {
         "I", "int" -> Int::class.javaPrimitiveType!!
+
         "Z", "boolean" -> Boolean::class.javaPrimitiveType!!
+
         "B", "byte" -> Byte::class.javaPrimitiveType!!
+
         "C", "char" -> Char::class.javaPrimitiveType!!
+
         "S", "short" -> Short::class.javaPrimitiveType!!
+
         "J", "long" -> Long::class.javaPrimitiveType!!
+
         "F", "float" -> Float::class.javaPrimitiveType!!
+
         "D", "double" -> Double::class.javaPrimitiveType!!
+
         "V", "void" -> Void.TYPE
+
         else -> {
             if (this.startsWith("L") && this.endsWith(";")) {
                 this.substring(1, this.length - 1).replace("/", ".").KavaRefExt_toClass(loader, initialize)
@@ -38,11 +47,9 @@ fun String.toClassOrNull(loader: ClassLoader? = null, initialize: Boolean = fals
     this.toClass(loader, initialize)
 }.getOrNull()
 
-fun Iterable<String>.toClasses(): Array<Class<*>> {
-    return this.map {
-        it.toClass()
-    }.toTypedArray()
-}
+fun Iterable<String>.toClasses(): Array<Class<*>> = this.map {
+    it.toClass()
+}.toTypedArray()
 
 fun Array<String>.toClasses(): Array<Class<*>> = Array(size) {
     get(it).toClass()

--- a/app/src/main/java/io/github/twyora/douyinenhancer/utils/Reflect.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/utils/Reflect.kt
@@ -57,7 +57,11 @@ fun <T : Any> Class<T>.resolveMethod(method: Method): MethodResolver<T>? {
         this.resolve().firstMethodOrNull {
             name = method.name
             method.parameters?.let {
-                parameters(*it.toClasses())
+                if (it.isEmpty()) {
+                    emptyParameters()
+                } else {
+                    parameters(*it.toClasses())
+                }
             }
             superclass()
         }

--- a/app/src/main/java/io/github/twyora/douyinenhancer/utils/Reflect.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/utils/Reflect.kt
@@ -1,7 +1,7 @@
 package io.github.twyora.douyinenhancer.utils
 
-import com.highcapable.kavaref.KavaRef.Companion.asResolver
 import com.highcapable.kavaref.KavaRef.Companion.resolve
+import com.highcapable.kavaref.extension.toClass as KavaRefExt_toClass
 import com.highcapable.kavaref.resolver.FieldResolver
 import com.highcapable.kavaref.resolver.MethodResolver
 import com.highcapable.yukihookapi.hook.log.YLog
@@ -10,118 +10,69 @@ data class Field(val name: String?)
 
 data class Method(val name: String?, val parameters: List<String>?)
 
-/**
- * Resolves a type name string into a format directly recognizable by reflection systems like KavaRef.
- *
- * @return Class for primitive type names, or the original String otherwise.
- */
-fun String.toClassIfPrimitiveElseString(): Any = when (this) {
-    // KavaRef's parameters() accepts Class or String. When given a String,
-    // it calls Class.forName() internally, which cannot resolve bare primitive
-    // type names like "int" or "boolean" and throws ClassNotFoundException.
-    // To work around this, we convert primitive type names to their corresponding
-    // java.lang.Class instances (e.g. "int" -> Integer.TYPE) so KavaRef hits
-    // the Class branch directly. Ordinary class names like "java.lang.String"
-    // are left as raw String, letting KavaRef resolve them via Class.forName()
-    // as intended.
-    "boolean" -> Boolean::class.java
-
-    "byte" -> Byte::class.java
-
-    "char" -> Char::class.java
-
-    "short" -> Short::class.java
-
-    "int" -> Int::class.java
-
-    "long" -> Long::class.java
-
-    "float" -> Float::class.java
-
-    "double" -> Double::class.java
-
-    "void" -> Void::class.java
-
-    else -> this
-}
-
-fun Array<String>.toClassIfPrimitiveElseString(): Array<Any> = Array(size) {
-    this[it].toClassIfPrimitiveElseString()
-}
-
-fun List<String>.toClassIfPrimitiveElseString(): Array<Any> = Array(size) {
-    this[it].toClassIfPrimitiveElseString()
-}
-
-fun Any.resolveMethod(method: Method): MethodResolver<*>? {
-    if (method.name.isNullOrBlank()) {
-        YLog.error("cannot determine which method to resolve on ${this::class.simpleName}, name is null or blank")
-        return null
+@JvmOverloads
+fun String.toClass(loader: ClassLoader? = null, initialize: Boolean = false): Class<*> {
+    // KavaRef's toClass doesn't support primitive types and JVM descriptors, manually handle them here
+    return when (this) {
+        "I", "int" -> Int::class.javaPrimitiveType!!
+        "Z", "boolean" -> Boolean::class.javaPrimitiveType!!
+        "B", "byte" -> Byte::class.javaPrimitiveType!!
+        "C", "char" -> Char::class.javaPrimitiveType!!
+        "S", "short" -> Short::class.javaPrimitiveType!!
+        "J", "long" -> Long::class.javaPrimitiveType!!
+        "F", "float" -> Float::class.javaPrimitiveType!!
+        "D", "double" -> Double::class.javaPrimitiveType!!
+        "V", "void" -> Void.TYPE
+        else -> {
+            if (this.startsWith("L") && this.endsWith(";")) {
+                this.substring(1, this.length - 1).replace("/", ".").KavaRefExt_toClass(loader, initialize)
+            } else {
+                this.KavaRefExt_toClass(loader, initialize)
+            }
+        }
     }
-    return runCatching {
-        this.asResolver().firstMethodOrNull {
-            name = method.name
-            method.parameters?.let {
-                parameters(*it.toClassIfPrimitiveElseString())
-            }
-            superclass()
-        }
-    }.onFailure {
-        YLog.error("resolve failed: ${this::class.simpleName}.${method.name}(${method.parameters})")
-    }.getOrNull()
-        .also {
-            if (it == null) {
-                YLog.error("method not found: ${this::class.simpleName}.${method.name}(${method.parameters})")
-            }
-        }
 }
 
-fun Any.resolveField(field: Field): FieldResolver<*>? {
-    if (field.name.isNullOrBlank()) {
-        YLog.error("cannot determine which field to resolve on ${this::class.simpleName}, name is null or blank")
-        return null
-    }
-    return runCatching {
-        this.asResolver().firstFieldOrNull {
-            name = field.name
-            superclass()
-        }
-    }.onFailure {
-        YLog.error("resolve failed: ${this::class.simpleName}.${field.name}")
-    }.getOrNull()
-        .also {
-            if (it == null) {
-                YLog.error("field not found: ${this::class.simpleName}.${field.name}")
-            }
-        }
+@JvmOverloads
+fun String.toClassOrNull(loader: ClassLoader? = null, initialize: Boolean = false) = runCatching {
+    this.toClass(loader, initialize)
+}.getOrNull()
+
+fun Iterable<String>.toClasses(): Array<Class<*>> {
+    return this.map {
+        it.toClass()
+    }.toTypedArray()
 }
 
-fun Class<*>.resolveMethod(method: Method): MethodResolver<*>? {
+fun Array<String>.toClasses(): Array<Class<*>> = Array(size) {
+    get(it).toClass()
+}
+
+fun <T : Any> Class<T>.resolveMethod(method: Method): MethodResolver<T>? {
     if (method.name.isNullOrBlank()) {
-        YLog.error("cannot determine which method to resolve on ${this.simpleName}, name is null or blank")
+        YLog.error("cannot determine which method to resolve on ${this.name}, name is null or blank")
         return null
     }
     return runCatching {
         this.resolve().firstMethodOrNull {
             name = method.name
             method.parameters?.let {
-                parameters(*it.toClassIfPrimitiveElseString())
+                parameters(*it.toClasses())
             }
             superclass()
         }
-    }.onFailure {
-        YLog.error("resolve failed: ${this.simpleName}.${method.name}(${method.parameters})")
-    }.getOrNull()
-        .also {
-            if (it == null) {
-                YLog.error("method not found: ${this.simpleName}.${method.name}(${method.parameters})")
-            }
+    }.onFailure { throwable ->
+        YLog.error("resolve failed: ${this.name}.${method.name}(${method.parameters})", throwable)
+    }.getOrNull().also {
+        if (it == null) {
+            YLog.error("method not found: ${this.name}.${method.name}(${method.parameters})")
         }
+    }
 }
 
-fun Class<*>.resolveField(field: Field): FieldResolver<*>? {
+fun <T : Any> Class<T>.resolveField(field: Field): FieldResolver<T>? {
     if (field.name.isNullOrBlank()) {
-        YLog.error("cannot determine which field to resolve on ${this.simpleName}, name is null or blank")
+        YLog.error("cannot determine which field to resolve on ${this.name}, name is null or blank")
         return null
     }
     return runCatching {
@@ -129,28 +80,39 @@ fun Class<*>.resolveField(field: Field): FieldResolver<*>? {
             name = field.name
             superclass()
         }
-    }.onFailure {
-        YLog.error("resolve failed: ${this.simpleName}.${field.name}")
-    }.getOrNull()
-        .also {
-            if (it == null) {
-                YLog.error("field not found: ${this.simpleName}.${field.name}")
-            }
+    }.onFailure { throwable ->
+        YLog.error("resolve failed: ${this.name}.${field.name}", throwable)
+    }.getOrNull().also {
+        if (it == null) {
+            YLog.error("field not found: ${this.name}.${field.name}")
         }
+    }
 }
 
-inline fun <reified T> Any.invokeMethod(method: Method, vararg args: Any?): T? = this.resolveMethod(method)?.invoke(*args) as? T
+fun <T : Any> T.resolveMethod(method: Method): MethodResolver<T>? {
+    @Suppress("UNCHECKED_CAST")
+    val thisClass = this::class.java as Class<T>
+    return thisClass.resolveMethod(method)?.of(this)
+}
+
+fun <T : Any> T.resolveField(field: Field): FieldResolver<T>? {
+    @Suppress("UNCHECKED_CAST")
+    val thisClass = this::class.java as Class<T>
+    return thisClass.resolveField(field)?.of(this)
+}
 
 inline fun <reified T> Class<*>.invokeStaticMethod(method: Method, vararg args: Any?): T? = this.resolveMethod(method)?.invoke(*args) as? T
 
-inline fun <reified T> Any.getField(field: Field): T? = this.resolveField(field)?.get() as? T
+inline fun <reified T> Any.invokeMethod(method: Method, vararg args: Any?): T? = this.resolveMethod(method)?.invoke(*args) as? T
 
-fun <T> Any.setField(field: Field, value: T?) {
-    this.resolveField(field)?.set(value)
+fun Any.invokeMethodOnly(method: Method, vararg args: Any?) {
+    this.invokeMethod<Any>(method, *args)
 }
 
 inline fun <reified T> Class<*>.getStaticField(field: Field): T? = this.resolveField(field)?.get() as? T
 
-fun <T> Class<*>.setStaticField(field: Field, value: T?) {
-    this.resolveField(field)?.set(value)
-}
+inline fun <reified T> Any.getField(field: Field): T? = this.resolveField(field)?.get() as? T
+
+fun Class<*>.setStaticField(field: Field, value: Any?) = this.resolveField(field)?.set(value)
+
+fun Any.setField(field: Field, value: Any?) = this.resolveField(field)?.set(value)

--- a/app/src/main/java/io/github/twyora/douyinenhancer/utils/Reflect.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/utils/Reflect.kt
@@ -47,12 +47,14 @@ fun String.toClassOrNull(loader: ClassLoader? = null, initialize: Boolean = fals
     this.toClass(loader, initialize)
 }.getOrNull()
 
-fun Iterable<String>.toClasses(): Array<Class<*>> = this.map {
-    it.toClass()
+@JvmOverloads
+fun Iterable<String>.toClasses(loader: ClassLoader? = null, initialize: Boolean = false): Array<Class<*>> = this.map {
+    it.toClass(loader, initialize)
 }.toTypedArray()
 
-fun Array<String>.toClasses(): Array<Class<*>> = Array(size) {
-    get(it).toClass()
+@JvmOverloads
+fun Array<String>.toClasses(loader: ClassLoader? = null, initialize: Boolean = false): Array<Class<*>> = Array(size) {
+    get(it).toClass(loader, initialize)
 }
 
 fun <T : Any> Class<T>.resolveMethod(method: Method): MethodResolver<T>? {
@@ -67,7 +69,7 @@ fun <T : Any> Class<T>.resolveMethod(method: Method): MethodResolver<T>? {
                 if (it.isEmpty()) {
                     emptyParameters()
                 } else {
-                    parameters(*it.toClasses())
+                    parameters(*it.toClasses(this@resolveMethod.classLoader))
                 }
             }
             superclass()


### PR DESCRIPTION
## Summary

- Replace the `toClassIfPrimitiveElseString` converters with KavaRef's `toClass` extension; add `toClassOrNull` and `Iterable`/`Array` `toClasses` helpers that resolve primitives and JVM descriptors in one place.
- Rework `resolveMethod`/`resolveField` into generic `Class<T>` and receiver `T` extensions delegating to the `Class` resolver.
- Apply `emptyParameters()` explicitly when the parameter list is empty to prevent KavaRef from ignoring the condition and incorrectly matching methods with arguments.
- Use `invokeMethodOnly` for side-effect-only calls.
- DouyinPackage.kt now uses the local `utils.toClass`.
