### PR TITLE
fix(settings-dialog): fix crash from wrong resolve target on onBindView

### DIFF
--- a/app/src/main/java/io/github/twyora/douyinenhancer/ui/SettingsDialog.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/ui/SettingsDialog.kt
@@ -429,7 +429,7 @@ class SettingsDialog(context: Context) : AlertDialog.Builder(ContextThemeWrapper
             if (verbose) {
                 YLog.debug("$TAG: night mode on, recoloring settings text white")
             }
-            Preference::class.resolveMethod(
+            Preference::class.java.resolveMethod(
                 Method(name = "onBindView", parameters = null)
             )?.hook {
                 after {


### PR DESCRIPTION
## Root cause
`SettingsDialog` hooked `Preference.onBindView` via `Preference::class.resolveMethod(...)`. `Preference::class` is a Kotlin `KClass`, so the `resolveMethod` extension inferred `T = KClass<Preference>` and resolved against `kotlin.jvm.internal.ClassReference` instead of `android.preference.Preference`, throwing `NoSuchMethodException` and crashing the settings dialog in night mode.

## Fix
Use `Preference::class.java` so the method resolves against the actual `android.preference.Preference` class.