### PR TITLE
feat(verify-dialog): add module download source verification dialog

### DIFF
--- a/app/src/main/java/io/github/twyora/douyinenhancer/config/key/ModuleKey.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/config/key/ModuleKey.kt
@@ -3,4 +3,5 @@ package io.github.twyora.douyinenhancer.config.key
 object ModuleKey {
     const val DISABLE_VERBOSE_LOGS = "disable_verbose_logs"
     const val NOTIFY_UPDATE_COOLDOWN = "notify_update_cooldown"
+    const val LAST_VERIFIED_VERSION = "last_verified_version"
 }

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/ui/VerifyDialogHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/ui/VerifyDialogHooker.kt
@@ -1,0 +1,63 @@
+package io.github.twyora.douyinenhancer.hook.ui
+
+import android.app.Activity
+import com.highcapable.yukihookapi.hook.entity.YukiBaseHooker
+import com.highcapable.yukihookapi.hook.log.YLog
+import io.github.twyora.douyinenhancer.BuildConfig
+import io.github.twyora.douyinenhancer.config.FastKVConfigManager
+import io.github.twyora.douyinenhancer.config.key.ModuleKey
+import io.github.twyora.douyinenhancer.hook.DouyinPackage
+import io.github.twyora.douyinenhancer.hook.HookOnMainProcess
+import io.github.twyora.douyinenhancer.ui.VerifyDialog
+import io.github.twyora.douyinenhancer.utils.resolveMethod
+
+@HookOnMainProcess
+object VerifyDialogHooker : YukiBaseHooker() {
+    private val TAG = this::class.simpleName
+
+    private val packageInstance
+        get() = DouyinPackage.instance
+
+    private val verbose
+        get() = !FastKVConfigManager.module.getBoolean(ModuleKey.DISABLE_VERBOSE_LOGS, false)
+
+    override fun onHook() {
+        if (BuildConfig.DEBUG) {
+            if (verbose) {
+                YLog.debug("$TAG: debug build, skipping verification check")
+            }
+            return
+        }
+
+        packageInstance.mainActivity.selfClass?.resolveMethod(
+            packageInstance.mainActivity.onResume()
+        )?.hook {
+            after {
+                val activity = instance as? Activity ?: run {
+                    YLog.error("$TAG: ${instance::class.qualifiedName} is not an Activity")
+                    return@after
+                }
+
+                val lastVerifiedVersion = FastKVConfigManager.module.getInt(
+                    ModuleKey.LAST_VERIFIED_VERSION,
+                    0
+                )
+                if (BuildConfig.VERSION_CODE != lastVerifiedVersion) {
+                    VerifyDialog.show(activity)
+                }
+                removeSelf {
+                    if (verbose) {
+                        YLog.debug("$TAG: verification check hook removed to prevent duplicate check")
+                    }
+                }
+            }
+        }?.result {
+            onConductFailure { _, throwable ->
+                YLog.error("$TAG: failed to show verify dialog on resume", throwable)
+            }
+            onHookingFailure { throwable ->
+                YLog.error("$TAG: failed to hook for showing verify dialog on resume", throwable)
+            }
+        }
+    }
+}

--- a/app/src/main/java/io/github/twyora/douyinenhancer/ui/SettingsDialog.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/ui/SettingsDialog.kt
@@ -480,11 +480,20 @@ class SettingsDialog(context: Context) : AlertDialog.Builder(ContextThemeWrapper
         private const val IMPORT_CONFIG = 1
 
         fun show(context: Context) {
-            runCatching {
-                (context as? Activity)?.injectModuleAppResources()
-                SettingsDialog(context).show()
-            }.onFailure {
-                YLog.error("$TAG: failed to show settings dialog", it)
+            val lastVerifiedVersion = FastKVConfigManager.module.getInt(
+                ModuleKey.LAST_VERIFIED_VERSION,
+                0
+            )
+            (context as? Activity)?.injectModuleAppResources()
+            if (BuildConfig.DEBUG || BuildConfig.VERSION_CODE == lastVerifiedVersion) {
+                runCatching {
+                    SettingsDialog(context).show()
+                }.onFailure {
+                    YLog.error("$TAG: failed to show settings dialog", it)
+                }
+            } else {
+                YLog.info("$TAG: unverified version, redirecting to verify dialog")
+                VerifyDialog.show(context)
             }
         }
 

--- a/app/src/main/java/io/github/twyora/douyinenhancer/ui/VerifyDialog.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/ui/VerifyDialog.kt
@@ -1,0 +1,80 @@
+package io.github.twyora.douyinenhancer.ui
+
+import android.app.Activity
+import android.app.AlertDialog
+import android.content.Context
+import android.view.ContextThemeWrapper
+import android.view.LayoutInflater
+import android.widget.Toast
+import androidx.core.content.edit
+import com.highcapable.yukihookapi.hook.factory.injectModuleAppResources
+import com.highcapable.yukihookapi.hook.log.YLog
+import io.github.twyora.douyinenhancer.BuildConfig
+import io.github.twyora.douyinenhancer.R
+import io.github.twyora.douyinenhancer.config.FastKVConfigManager
+import io.github.twyora.douyinenhancer.config.key.ModuleKey
+import io.github.twyora.douyinenhancer.databinding.VerifyDialogBinding
+
+class VerifyDialog(private val hostContext: Context) : AlertDialog.Builder(ContextThemeWrapper(hostContext, R.style.MainTheme)) {
+    private val binding = VerifyDialogBinding.inflate(
+        LayoutInflater.from(ContextThemeWrapper(context, R.style.MainTheme))
+    )
+
+    init {
+        setView(binding.root)
+        setTitle(R.string.verify_dialog_title)
+        setNegativeButton(android.R.string.cancel, null)
+        // just shows the positive button; click handling is set in show
+        setPositiveButton(android.R.string.ok, null)
+    }
+
+    override fun show(): AlertDialog {
+        val dialog = super.show()
+        dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener {
+            val inputUrl = binding.verifyInput.text.toString()
+            val valid = context.resources.getStringArray(
+                R.array.valid_verification_urls
+            ).any {
+                inputUrl.contains(it, ignoreCase = true)
+            }
+            if (valid) {
+                moduleConfig.edit(true) {
+                    putInt(ModuleKey.LAST_VERIFIED_VERSION, BuildConfig.VERSION_CODE)
+                }
+                dialog.dismiss()
+
+                (hostContext as? Activity)?.runOnUiThread {
+                    Toast.makeText(context, context.getString(R.string.verify_toast_success), Toast.LENGTH_SHORT).show()
+                }
+            } else {
+                (hostContext as? Activity)?.runOnUiThread {
+                    Toast.makeText(context, context.getString(R.string.verify_toast_failure), Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
+        return dialog
+    }
+
+    companion object {
+        private val TAG = this::class.simpleName
+
+        private val moduleConfig
+            get() = FastKVConfigManager.module
+
+        fun show(context: Context) {
+            val lastVerifiedVersion = moduleConfig.getInt(
+                ModuleKey.LAST_VERIFIED_VERSION,
+                0
+            )
+            if (BuildConfig.DEBUG || BuildConfig.VERSION_CODE == lastVerifiedVersion) {
+                return
+            }
+            runCatching {
+                (context as? Activity)?.injectModuleAppResources()
+                VerifyDialog(context).show()
+            }.onFailure {
+                YLog.error("$TAG: failed to show verify dialog", it)
+            }
+        }
+    }
+}

--- a/app/src/main/res/layout/verify_dialog.xml
+++ b/app/src/main/res/layout/verify_dialog.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingStart="24dp"
+        android:paddingEnd="24dp"
+        android:paddingTop="16dp"
+        android:paddingBottom="16dp">
+
+        <TextView
+            android:id="@+id/verify_dialog_summary"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/verify_dialog_description"
+            android:textAppearance="?android:attr/textAppearanceListItemSecondary"
+            android:lineSpacingMultiplier="1.2"
+            android:paddingTop="12dp"
+            android:paddingBottom="12dp" />
+
+        <EditText
+            android:id="@+id/verify_input"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/verify_dialog_input_hint"
+            android:inputType="textMultiLine"
+            android:autofillHints=""
+            android:textAppearance="?android:attr/textAppearanceListItem" />
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/values-zh-rCN/values-zh.xml
+++ b/app/src/main/res/values-zh-rCN/values-zh.xml
@@ -152,6 +152,12 @@
     <string name="pref_module_disable_verbose_logs_title">禁用详细日志</string>
     <string name="pref_module_disable_verbose_logs_summary">报告问题要求包含详细日志</string>
 
+    <string name="verify_dialog_title">验证</string>
+    <string name="verify_dialog_description">模块仅在 GitHub 发布！为了尊重开发者的劳动成果，请输入模块下载地址进行验证。使用前请认真阅读仓库 README。</string>
+    <string name="verify_dialog_input_hint">GitHub 地址</string>
+    <string name="verify_toast_success">验证成功</string>
+    <string name="verify_toast_failure">输入内容不正确，请重试</string>
+
     <string name="pref_category_about">关于</string>
     <string name="pref_about_version_title">版本</string>
     <string name="pref_about_version_summary">0.0.1</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -153,6 +153,12 @@
     <string name="pref_module_disable_verbose_logs_title">Disable verbose logs</string>
     <string name="pref_module_disable_verbose_logs_summary">Report issues request to include verbose logs</string>
 
+    <string name="verify_dialog_title">Verification</string>
+    <string name="verify_dialog_description">This module is released only on GitHub. To respect the developer’s work, enter the module download URL for verification. Please read the repository README carefully before use.</string>
+    <string name="verify_dialog_input_hint">GitHub address</string>
+    <string name="verify_toast_success">Verified</string>
+    <string name="verify_toast_failure">Incorrect input, please try again</string>
+
     <string name="pref_category_about">About</string>
     <string name="pref_about_version_title">Version</string>
     <string name="pref_about_version_summary">0.0.1</string>

--- a/app/src/main/res/values/strings_raw.xml
+++ b/app/src/main/res/values/strings_raw.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="author_url">https://github.com/twyora</string>
     <string name="repository_url">https://github.com/twyora/DouyinEnhancer</string>
     <string name="telegram_url">https://t.me/+d8bFo0maZQs4MTk1</string>
     <string name="latest_release_page_url">https://github.com/twyora/DouyinEnhancer/releases/latest</string>
     <string name="latest_release_api_url">https://api.github.com/repos/twyora/DouyinEnhancer/releases/latest</string>
+    <string-array name="valid_verification_urls">
+        <item>github.com/twyora/DouyinEnhancer</item>
+        <item>github.com/Xposed-Modules-Repo/io.github.twyora.douyinenhancer</item>
+    </string-array>
 </resources>


### PR DESCRIPTION
Add a verification gate that requires users to enter a valid GitHub repository URL before using the module