### PR TITLE
refactor(feed-download): replace ActionStatus valueOf call with direct static field access

### DIFF
--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/DouyinPackage.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/DouyinPackage.kt
@@ -50,10 +50,9 @@ val Configs.Method.nameOrNull
     }
 
 val Configs.Method.Parameters.valuesListOrNull
-    get() =
-        valuesList.ifEmpty {
-            null
-        }
+    get() = valuesList.ifEmpty {
+        null
+    }
 
 class DouyinPackage(classLoader: ClassLoader, context: Context) {
     private val hookInfo: Configs.HookInfo = run {

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/DouyinPackage.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/DouyinPackage.kt
@@ -974,11 +974,6 @@ class DouyinPackage(classLoader: ClassLoader, context: Context) {
             configs.class_.nameOrNull?.toClass(classLoader)
         }
 
-        fun valueOf() = Method(
-            configs.valueOf.nameOrNull,
-            configs.valueOf.parameters.valuesListOrNull
-        )
-
         fun grayed() = Field(configs.grayed.nameOrNull)
 
         fun hidden() = Field(configs.hidden.nameOrNull)
@@ -2390,9 +2385,6 @@ class DouyinPackage(classLoader: ClassLoader, context: Context) {
                 actionStatus = actionStatus {
                     class_ = class_ {
                         name = "com.ss.android.ugc.aweme.privacy.model.ActionStatus"
-                    }
-                    valueOf = method {
-                        name = "valueOf"
                     }
                     grayed = field {
                         name = "GRAYED"

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/FeedDownloadHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/FeedDownloadHooker.kt
@@ -11,6 +11,7 @@ import io.github.twyora.douyinenhancer.hook.DouyinPackage
 import io.github.twyora.douyinenhancer.hook.HookOnMainProcess
 import io.github.twyora.douyinenhancer.utils.HookTransaction
 import io.github.twyora.douyinenhancer.utils.getField
+import io.github.twyora.douyinenhancer.utils.getStaticField
 import io.github.twyora.douyinenhancer.utils.invokeMethod
 import io.github.twyora.douyinenhancer.utils.invokeStaticMethod
 import io.github.twyora.douyinenhancer.utils.resolveMethod
@@ -66,9 +67,8 @@ object FeedDownloadHooker : YukiBaseHooker() {
                     return@after
                 }
 
-                val normalStatus = packageInstance.actionStatus.selfClass?.invokeStaticMethod<Any>(
-                    packageInstance.actionStatus.valueOf(),
-                    packageInstance.actionStatus.normal().name
+                val normalStatus = packageInstance.actionStatus.selfClass?.getStaticField<Any>(
+                    packageInstance.actionStatus.normal()
                 )
 
                 if (actionStatus != normalStatus) {

--- a/app/src/main/proto/io/github/twyora/douyinenhancer/hook/configs.proto
+++ b/app/src/main/proto/io/github/twyora/douyinenhancer/hook/configs.proto
@@ -258,10 +258,11 @@ message ActionCheckResult {
 
 message ActionStatus {
   optional Class class = 1;
-  optional Method value_of = 2;
   optional Field grayed = 3;
   optional Field hidden = 4;
   optional Field normal = 5;
+
+  reserved 2;
 }
 
 message GalleryShareHelper {


### PR DESCRIPTION
Remove the `ActionStatus.valueOf` proto field and its `DouyinPackage` mapping. `FeedDownloadHooker` now reads the normal download status via direct static field access instead of invoking the static `valueOf` method.