### PR TITLE
fix(res): rename enabled activation status key to match activated/deactivated style

### DIFF
--- a/app/src/main/java/io/github/twyora/douyinenhancer/ui/MainActivity.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/ui/MainActivity.kt
@@ -61,7 +61,7 @@ class MainActivity : Activity() {
                 SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault()).format(BuildConfig.BUILD_TIMESTAMP)
             if (YukiHookAPI.Status.isModuleActive) {
                 val activationStatus = findPreference("activation_status")
-                activationStatus?.title = context.getString(R.string.pref_about_activation_status_enabled_title)
+                activationStatus?.title = context.getString(R.string.pref_about_activation_status_activated_title)
                 activationStatus?.summary = context.getString(R.string.pref_about_activation_status_activated_summary)
             }
 

--- a/app/src/main/res/values-zh-rCN/values-zh.xml
+++ b/app/src/main/res/values-zh-rCN/values-zh.xml
@@ -191,6 +191,6 @@
     <string name="pref_settings_hide_launcher_icon_summary">不显示本应用在启动器中的图标</string>
     <string name="pref_about_activation_status_disabled_title">未启用</string>
     <string name="pref_about_activation_status_deactivated_summary">抖柚未激活</string>
-    <string name="pref_about_activation_status_enabled_title">已启用</string>
+    <string name="pref_about_activation_status_activated_title">已启用</string>
     <string name="pref_about_activation_status_activated_summary">抖柚已激活</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -191,6 +191,6 @@
     <string name="pref_settings_hide_launcher_icon_summary">Don\'t show this app\'s icon in the launcher</string>
     <string name="pref_about_activation_status_disabled_title">Not enabled</string>
     <string name="pref_about_activation_status_deactivated_summary">Douyin Enhancer not activated</string>
-    <string name="pref_about_activation_status_enabled_title">Enabled</string>
+    <string name="pref_about_activation_status_activated_title">Enabled</string>
     <string name="pref_about_activation_status_activated_summary">Douyin Enhancer activated</string>
 </resources>


### PR DESCRIPTION
Rename `pref_about_activation_status_enabled_title` to `pref_about_activation_status_activated_title`