### PR TITLE
refactor(feed): pause playback after resume instead of blocking the event

### DIFF
--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/FeedResumeHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/feed/FeedResumeHooker.kt
@@ -8,6 +8,7 @@ import io.github.twyora.douyinenhancer.config.key.ModuleKey
 import io.github.twyora.douyinenhancer.hook.DouyinPackage
 import io.github.twyora.douyinenhancer.hook.HookOnMainProcess
 import io.github.twyora.douyinenhancer.utils.getField
+import io.github.twyora.douyinenhancer.utils.invokeMethodOnly
 import io.github.twyora.douyinenhancer.utils.resolveMethod
 
 @HookOnMainProcess
@@ -30,27 +31,32 @@ object FeedResumeHooker : YukiBaseHooker() {
 
         // I have another choice: intercept FeedPanelProxy.handleTextureAvailable,
         // (the name "FeedPanelProxy" is given by me; it is obfuscated by the host and owned by BaseListFragmentPanel.basePanelProxy)
-        // instead of checking videoType using a magic number inside BaseListFragmentPanel.handleVideoEvent.
+        // instead of checking videoType inside BaseListFragmentPanel.handleVideoEvent.
         // The reason I ultimately chose this strategy is that I cannot confirm whether FeedPanelProxy
         // will be removed or obfuscated into another name. If this functionality breaks,
         // maintaining extra hook points becomes an additional maintenance burden
         packageInstance.baseListFragmentPanel.selfClass?.resolveMethod(
             packageInstance.baseListFragmentPanel.handleVideoEvent()
         )?.hook {
-            before {
+            after {
                 val videoType = args[0]?.getField<Int>(
                     packageInstance.videoEvent.videoType()
                 ) ?: run {
                     YLog.error("$TAG: video type is null")
-                    return@before
+                    return@after
                 }
 
                 if (videoType != DouyinPackage.VideoEventModule.EVENT_TEXTURE_AVAILABLE) {
-                    return@before
+                    return@after
                 } else if (verbose) {
-                    YLog.debug("$TAG: intercepting resume of video playback on surface created")
+                    YLog.debug("$TAG: pause playback on resume")
                 }
-                resultNull()
+                instance.invokeMethodOnly(
+                    packageInstance.baseListFragmentPanel.pauseCurrentPlayerWithListener()
+                )
+                instance.invokeMethodOnly(
+                    packageInstance.baseListFragmentPanel.showIvWhenPause()
+                )
             }
         }?.result {
             onConductFailure { _, throwable ->

--- a/app/src/main/res/values-zh-rCN/values-zh.xml
+++ b/app/src/main/res/values-zh-rCN/values-zh.xml
@@ -31,7 +31,7 @@
     <string name="pref_feed_block_auto_replay_title">阻止自动重播</string>
     <string name="pref_feed_block_auto_replay_summary">在视频播放完毕之后自动暂停视频</string>
     <string name="pref_feed_block_resume_playback_title">阻止恢复播放</string>
-    <string name="pref_feed_block_resume_playback_summary">返回前台时不主动恢复视频播放</string>
+    <string name="pref_feed_block_resume_playback_summary">返回前台时自动暂停视频</string>
     <string name="pref_ui_keep_danmaku_visible_title">阻止弹幕隐藏</string>
     <string name="pref_ui_keep_danmaku_visible_summary">使弹幕在清屏模式下仍然保持可见</string>
     <string name="recommended_feed_filter_main_switch_title">总开关</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,7 +30,7 @@
     <string name="pref_feed_block_auto_replay_title">Block Auto Replay</string>
     <string name="pref_feed_block_auto_replay_summary">Pause video once playback completes</string>
     <string name="pref_feed_block_resume_playback_title">Block Resume Playback</string>
-    <string name="pref_feed_block_resume_playback_summary">Prevent automatic video resumption when returning to the foreground</string>
+    <string name="pref_feed_block_resume_playback_summary">Automatically pause video when returning to the foreground</string>
     <string name="pref_ui_keep_danmaku_visible_title">Keep Danmaku Visible</string>
     <string name="pref_ui_keep_danmaku_visible_summary">Keep danmaku visible when entering clean mode</string>
     <string name="recommended_feed_filter_main_switch_title">Main switch</string>


### PR DESCRIPTION
`FeedResumeHooker` now lets the host finish its resume flow and pauses the player manually afterwards, instead of blocking the resume event which caused broken UI restoration. The settings summary is updated to describe auto-pause on return.