### PR TITLE
refactor(settings-entry): restructure settings entry hooks

### DIFF
--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/ui/SettingsEntryHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/ui/SettingsEntryHooker.kt
@@ -89,7 +89,7 @@ object SettingsEntryHooker : YukiBaseHooker() {
                 )
 
                 moduleSettingsCommonItemView.setOnClickListener {
-                    SettingsDialog.Companion.show(activity)
+                    SettingsDialog.show(activity)
                 }
 
                 // prefer inserting above the logout button; fallback to direct insert
@@ -146,7 +146,7 @@ object SettingsEntryHooker : YukiBaseHooker() {
                     YLog.debug("$TAG: attaching long click listener on about_ame view to open settings dialog")
                 }
                 aboutAwemeView.setOnLongClickListener {
-                    SettingsDialog.Companion.show(activity)
+                    SettingsDialog.show(activity)
                     true
                 }
             }

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/ui/SettingsEntryHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/ui/SettingsEntryHooker.kt
@@ -1,4 +1,4 @@
-package io.github.twyora.douyinenhancer.hook.settings
+package io.github.twyora.douyinenhancer.hook.ui
 
 import android.app.Activity
 import android.view.View
@@ -21,7 +21,7 @@ import io.github.twyora.douyinenhancer.utils.invokeMethodOnly
 import io.github.twyora.douyinenhancer.utils.resolveMethod
 
 @HookOnMainProcess
-object SettingsHooker : YukiBaseHooker() {
+object SettingsEntryHooker : YukiBaseHooker() {
     private val TAG = this::class.simpleName
 
     private val packageInstance
@@ -59,10 +59,11 @@ object SettingsHooker : YukiBaseHooker() {
                 }
 
                 val moduleSettingsCommonItemView =
-                    packageInstance.commonItemView.selfClass?.createInstance(activity, null) as? ViewGroup ?: run {
-                        YLog.error("$TAG: failed to create module settings entry")
-                        return@after
-                    }
+                    packageInstance.commonItemView.selfClass?.createInstance(activity, null) as? ViewGroup
+                        ?: run {
+                            YLog.error("$TAG: failed to create module settings entry")
+                            return@after
+                        }
 
                 moduleSettingsCommonItemView.apply {
                     tag = moduleSettingsTag
@@ -88,7 +89,7 @@ object SettingsHooker : YukiBaseHooker() {
                 )
 
                 moduleSettingsCommonItemView.setOnClickListener {
-                    SettingsDialog.show(activity)
+                    SettingsDialog.Companion.show(activity)
                 }
 
                 // prefer inserting above the logout button; fallback to direct insert
@@ -145,7 +146,7 @@ object SettingsHooker : YukiBaseHooker() {
                     YLog.debug("$TAG: attaching long click listener on about_ame view to open settings dialog")
                 }
                 aboutAwemeView.setOnLongClickListener {
-                    SettingsDialog.show(activity)
+                    SettingsDialog.Companion.show(activity)
                     true
                 }
             }

--- a/app/src/main/java/io/github/twyora/douyinenhancer/hook/ui/SettingsEntryIntentHooker.kt
+++ b/app/src/main/java/io/github/twyora/douyinenhancer/hook/ui/SettingsEntryIntentHooker.kt
@@ -12,7 +12,7 @@ import io.github.twyora.douyinenhancer.ui.SettingsDialog
 import io.github.twyora.douyinenhancer.utils.resolveMethod
 
 @HookOnMainProcess
-object MainActivityHooker : YukiBaseHooker() {
+object SettingsEntryIntentHooker : YukiBaseHooker() {
     private val TAG = this::class.simpleName
 
     private val packageInstance


### PR DESCRIPTION
Move the settings entry hook from the `settings` package into `hook.ui` and rename it to `SettingsEntryHooker`, and rename `MainActivityHooker` to `SettingsEntryIntentHooker` so both settings-entry hooks live under `hook.ui` with names that reflect their actual role.